### PR TITLE
Fix command type

### DIFF
--- a/nonebot/plugin.py
+++ b/nonebot/plugin.py
@@ -142,7 +142,7 @@ def on_endswith(msg: str,
                           startswith(msg), permission, **kwargs)
 
 
-def on_command(cmd: Union[str, Tuple[str]],
+def on_command(cmd: Union[str, Tuple[str, ...]],
                rule: Optional[Union[Rule, RuleChecker]] = None,
                permission: Permission = Permission(),
                **kwargs) -> Type[Matcher]:

--- a/nonebot/rule.py
+++ b/nonebot/rule.py
@@ -105,7 +105,7 @@ def keyword(msg: str) -> Rule:
     return Rule(_keyword)
 
 
-def command(command: Tuple[str]) -> Rule:
+def command(command: Tuple[str, ...]) -> Rule:
     config = get_driver().config
     command_start = config.command_start
     command_sep = config.command_sep


### PR DESCRIPTION
https://docs.python.org/3/library/typing.html#typing.Tuple

> To specify a variable-length tuple of homogeneous type, use literal ellipsis, e.g. Tuple[int, ...].