### PR TITLE
🐛 fix reply wont remove backward compatibility @AT

### DIFF
--- a/nonebot/adapters/cqhttp/__init__.py
+++ b/nonebot/adapters/cqhttp/__init__.py
@@ -115,7 +115,7 @@ async def _check_reply(bot: "Bot", event: "Event"):
     # ensure string comparation
     if str(event.reply["sender"]["user_id"]) == str(event.self_id):
         event.to_me = True
-    del event.message[index]
+    del event.message[index], event.message[index]
     if not event.message:
         event.message.append(MessageSegment.text(""))
 


### PR DESCRIPTION
中文(For english please translate yourself, sry): 


这个bug老早了, 我自己修复完都忘记PR了
就是今天更新才发现指令全部失效才想起这个


老代码:
```python
del event.message[index]
```
执行后的问题: **AT**没清除干净
```
[CQ:at,qq=12306] /(执行不了的指令)
```
解决方案: 一次过移除两个 (代码合理即可)
```python
del event.message[index], event.message[index]
```
这样写可以连带把Reply因为需要支援旧版本而额外添加的At Reply清除掉

如果可以, 我建议可以这样判断, 因为已知后面的At必是Reply的Target
```python
msg_seg = event.message[index]
at_seg = event.message[index+1]
event.reply = await bot.get_msg(message_id=msg_seg.data["id"])
# ensure string comparation
if event.reply["sender"]["user_id"] == event.self_id or str(at_seg.data["qq"]) == str(event.self_id):
    event.to_me = True
```