### PR TITLE
Refactor: 更新内置 register_adapter 逻辑

### DIFF
--- a/nonebot/__init__.py
+++ b/nonebot/__init__.py
@@ -138,7 +138,6 @@ def get_bots() -> Union[NoReturn, Dict[str, Bot]]:
 from nonebot.utils import escape_tag
 from nonebot.config import Env, Config
 from nonebot.log import logger, default_filter
-from nonebot.adapters.cqhttp import Bot as CQBot
 
 
 def init(*, _env_file: Optional[str] = None, **kwargs):
@@ -183,9 +182,6 @@ def init(*, _env_file: Optional[str] = None, **kwargs):
         DriverClass: Type[Driver] = getattr(
             importlib.import_module(config.driver), "Driver")
         _driver = DriverClass(env, config)
-
-        # register build-in adapters
-        _driver.register_adapter("cqhttp", CQBot)
 
 
 def run(host: Optional[str] = None,

--- a/nonebot/drivers/__init__.py
+++ b/nonebot/drivers/__init__.py
@@ -123,7 +123,8 @@ class BaseDriver(abc.ABC):
           * ``*args``
           * ``**kwargs``
         """
-        raise NotImplementedError
+        logger.opt(
+            colors=True).debug(f"Loaded adapters: {', '.join(self._adapters)}")
 
     @abc.abstractmethod
     async def _handle_http(self):

--- a/nonebot/drivers/__init__.py
+++ b/nonebot/drivers/__init__.py
@@ -123,8 +123,8 @@ class BaseDriver(abc.ABC):
           * ``*args``
           * ``**kwargs``
         """
-        logger.opt(
-            colors=True).debug(f"Loaded adapters: {', '.join(self._adapters)}")
+        logger.opt(colors=True).debug(
+            f"<g>Loaded adapters: {', '.join(self._adapters)}</g>")
 
     @abc.abstractmethod
     async def _handle_http(self):

--- a/nonebot/drivers/fastapi.py
+++ b/nonebot/drivers/fastapi.py
@@ -98,6 +98,7 @@ class Driver(BaseDriver):
             app: Optional[str] = None,
             **kwargs):
         """使用 ``uvicorn`` 启动 FastAPI"""
+        super().run(host, port, app, **kwargs)
         LOGGING_CONFIG = {
             "version": 1,
             "disable_existing_loggers": False,

--- a/tests/bot.py
+++ b/tests/bot.py
@@ -4,6 +4,7 @@ import sys
 sys.path.insert(0, os.path.abspath(".."))
 
 import nonebot
+from nonebot.adapters.cqhttp import Bot
 from nonebot.log import logger, default_format
 
 # test custom log
@@ -15,6 +16,8 @@ logger.add("error.log",
 
 nonebot.init(custom_config2="config on init")
 app = nonebot.get_asgi()
+driver = nonebot.get_driver()
+driver.register_adapter("cqhttp", Bot)
 
 # load builtin plugin
 nonebot.load_builtin_plugins()
@@ -25,7 +28,7 @@ nonebot.load_plugins("test_plugins")
 print(nonebot.require("test_export"))
 
 # modify some config / config depends on loaded configs
-config = nonebot.get_driver().config
+config = driver.config
 config.custom_config3 = config.custom_config1
 config.custom_config4 = "New custom config"
 


### PR DESCRIPTION
不再由 NoneBot 自行注册协议适配器

由用户在 `nonebot.run` 之前选择需要的协议适配进行注册

```python
# bot.py
import nonebot
from nonebot.adapters.cqhttp import Bot

nonebot.init()
driver = nonebot.get_driver()
driver.register_adapter("cqhttp", Bot)
```