### PR TITLE
修复几个错误的类型声明

### DIFF
--- a/nonebot/__init__.py
+++ b/nonebot/__init__.py
@@ -26,7 +26,7 @@
 
 import importlib
 import pkg_resources
-from nonebot.typing import Bot, Dict, Type, Union, Driver, Optional, NoReturn
+from nonebot.typing import Bot, Dict, Type, Union, Driver, Optional
 
 _dist: pkg_resources.Distribution = pkg_resources.get_distribution("nonebot2")
 __version__ = _dist.version

--- a/nonebot/__init__.py
+++ b/nonebot/__init__.py
@@ -35,7 +35,7 @@ VERSION = _dist.parsed_version
 _driver: Optional[Driver] = None
 
 
-def get_driver() -> Union[NoReturn, Driver]:
+def get_driver() -> Driver:
     """
     :说明:
 
@@ -111,7 +111,7 @@ def get_asgi():
     return driver.asgi
 
 
-def get_bots() -> Union[NoReturn, Dict[str, Bot]]:
+def get_bots() -> Dict[str, Bot]:
     """
     :说明:
 

--- a/nonebot/adapters/__init__.py
+++ b/nonebot/adapters/__init__.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 from nonebot.config import Config
 from nonebot.typing import Driver, Message, WebSocket
-from nonebot.typing import Any, Dict, Union, Optional, NoReturn, Callable, Iterable, Awaitable, TypeVar, Generic
+from nonebot.typing import Any, Dict, Union, Optional, Callable, Iterable, Awaitable, TypeVar, Generic
 
 
 class BaseBot(abc.ABC):
@@ -61,8 +61,7 @@ class BaseBot(abc.ABC):
     @classmethod
     @abc.abstractmethod
     async def check_permission(cls, driver: Driver, connection_type: str,
-                               headers: dict,
-                               body: Optional[dict]) -> Union[str, NoReturn]:
+                               headers: dict, body: Optional[dict]) -> str:
         """
         :说明:
 

--- a/nonebot/adapters/cqhttp/bot.py
+++ b/nonebot/adapters/cqhttp/bot.py
@@ -12,7 +12,7 @@ from nonebot.adapters import BaseBot
 from nonebot.message import handle_event
 from nonebot.exception import RequestDenied
 from nonebot.typing import Any, Dict, Union, Optional
-from nonebot.typing import overrides, Driver, WebSocket, NoReturn
+from nonebot.typing import overrides, Driver, WebSocket
 
 from .event import Event
 from .message import Message, MessageSegment
@@ -20,8 +20,7 @@ from .exception import NetworkError, ApiNotAvailable, ActionFailed
 from .utils import log
 
 
-def get_auth_bearer(
-        access_token: Optional[str] = None) -> Union[Optional[str], NoReturn]:
+def get_auth_bearer(access_token: Optional[str] = None) -> Optional[str]:
     if not access_token:
         return None
     scheme, _, param = access_token.partition(" ")
@@ -153,8 +152,7 @@ def _check_nickname(bot: "Bot", event: "Event"):
             first_msg_seg.data["text"] = first_text[m.end():]
 
 
-def _handle_api_result(
-        result: Optional[Dict[str, Any]]) -> Union[Any, NoReturn]:
+def _handle_api_result(result: Optional[Dict[str, Any]]) -> Any:
     """
     :说明:
 
@@ -238,8 +236,7 @@ class Bot(BaseBot):
     @classmethod
     @overrides(BaseBot)
     async def check_permission(cls, driver: Driver, connection_type: str,
-                               headers: dict,
-                               body: Optional[dict]) -> Union[str, NoReturn]:
+                               headers: dict, body: Optional[dict]) -> str:
         """
         :说明:
 
@@ -310,7 +307,7 @@ class Bot(BaseBot):
             )
 
     @overrides(BaseBot)
-    async def call_api(self, api: str, **data) -> Union[Any, NoReturn]:
+    async def call_api(self, api: str, **data) -> Any:
         """
         :说明:
 
@@ -382,7 +379,7 @@ class Bot(BaseBot):
                    event: Event,
                    message: Union[str, Message, MessageSegment],
                    at_sender: bool = False,
-                   **kwargs) -> Union[Any, NoReturn]:
+                   **kwargs) -> Any:
         """
         :说明:
 

--- a/nonebot/adapters/cqhttp/bot.pyi
+++ b/nonebot/adapters/cqhttp/bot.pyi
@@ -2,14 +2,13 @@ import asyncio
 
 from nonebot.config import Config
 from nonebot.adapters import BaseBot
-from nonebot.typing import Any, Dict, List, Union, Driver, Optional, NoReturn, WebSocket
+from nonebot.typing import Any, Dict, List, Union, Driver, Optional, WebSocket
 
 from .event import Event
 from .message import Message, MessageSegment
 
 
-def get_auth_bearer(
-        access_token: Optional[str] = ...) -> Union[Optional[str], NoReturn]:
+def get_auth_bearer(access_token: Optional[str] = ...) -> Optional[str]:
     ...
 
 
@@ -25,8 +24,7 @@ def _check_nickname(bot: "Bot", event: Event):
     ...
 
 
-def _handle_api_result(
-        result: Optional[Dict[str, Any]]) -> Union[Any, NoReturn]:
+def _handle_api_result(result: Optional[Dict[str, Any]]) -> Any:
     ...
 
 
@@ -63,19 +61,18 @@ class Bot(BaseBot):
 
     @classmethod
     async def check_permission(cls, driver: Driver, connection_type: str,
-                               headers: dict,
-                               body: Optional[dict]) -> Union[str, NoReturn]:
+                               headers: dict, body: Optional[dict]) -> str:
         ...
 
     async def handle_message(self, message: dict):
         ...
 
-    async def call_api(self, api: str, **data) -> Union[Any, NoReturn]:
+    async def call_api(self, api: str, **data) -> Any:
         ...
 
     async def send(self, event: Event, message: Union[str, Message,
                                                       MessageSegment],
-                   **kwargs) -> Union[Any, NoReturn]:
+                   **kwargs) -> Any:
         ...
 
     async def send_private_msg(self,

--- a/nonebot/adapters/ding/bot.py
+++ b/nonebot/adapters/ding/bot.py
@@ -8,7 +8,7 @@ from nonebot.config import Config
 from nonebot.adapters import BaseBot
 from nonebot.message import handle_event
 from nonebot.exception import RequestDenied
-from nonebot.typing import Any, Union, Driver, Optional, NoReturn
+from nonebot.typing import Any, Union, Driver, Optional
 
 from .utils import log
 from .event import Event
@@ -86,7 +86,7 @@ class Bot(BaseBot):
     async def call_api(self,
                        api: str,
                        event: Optional[Event] = None,
-                       **data) -> Union[Any, NoReturn]:
+                       **data) -> Any:
         """
         :说明:
 
@@ -159,7 +159,7 @@ class Bot(BaseBot):
                    event: Event,
                    message: Union[str, "Message", "MessageSegment"],
                    at_sender: bool = False,
-                   **kwargs) -> Union[Any, NoReturn]:
+                   **kwargs) -> Any:
         """
         :说明:
 

--- a/nonebot/message.py
+++ b/nonebot/message.py
@@ -12,7 +12,7 @@ from nonebot.log import logger
 from nonebot.rule import TrieRule
 from nonebot.utils import escape_tag
 from nonebot.matcher import matchers, Matcher
-from nonebot.typing import Set, Type, Union, Optional, Iterable, NoReturn, Bot, Event
+from nonebot.typing import Set, Type, Optional, Iterable, Bot, Event
 from nonebot.exception import IgnoredException, StopPropagation
 from nonebot.typing import EventPreProcessor, RunPreProcessor, EventPostProcessor, RunPostProcessor
 
@@ -137,7 +137,7 @@ async def _check_matcher(priority: int, bot: Bot, event: Event,
 
 
 async def _run_matcher(Matcher: Type[Matcher], bot: Bot, event: Event,
-                       state: dict) -> Union[None, NoReturn]:
+                       state: dict) -> None:
     logger.info(f"Event will be handled by {Matcher}")
 
     matcher = Matcher()
@@ -183,6 +183,7 @@ async def _run_matcher(Matcher: Type[Matcher], bot: Bot, event: Event,
 
     if matcher.block or isinstance(exception, StopPropagation):
         raise StopPropagation
+    return
 
 
 async def handle_event(bot: Bot, event: Event):

--- a/nonebot/typing.py
+++ b/nonebot/typing.py
@@ -92,37 +92,34 @@ MessageSegment = TypeVar("MessageSegment", bound="BaseMessageSegment")
   所有 MessageSegment 的基类。
 """
 
-EventPreProcessor = Callable[[Bot, Event, dict], Union[Awaitable[None],
-                                                       Awaitable[NoReturn]]]
+EventPreProcessor = Callable[[Bot, Event, dict], Awaitable[None]]
 """
-:类型: ``Callable[[Bot, Event, dict], Union[Awaitable[None], Awaitable[NoReturn]]]``
+:类型: ``Callable[[Bot, Event, dict], Awaitable[None]]``
 
 :说明:
 
   事件预处理函数 EventPreProcessor 类型
 """
-EventPostProcessor = Callable[[Bot, Event, dict], Union[Awaitable[None],
-                                                        Awaitable[NoReturn]]]
+EventPostProcessor = Callable[[Bot, Event, dict], Awaitable[None]]
 """
-:类型: ``Callable[[Bot, Event, dict], Union[Awaitable[None], Awaitable[NoReturn]]]``
+:类型: ``Callable[[Bot, Event, dict], Awaitable[None]]``
 
 :说明:
 
   事件预处理函数 EventPostProcessor 类型
 """
-RunPreProcessor = Callable[["Matcher", Bot, Event, dict],
-                           Union[Awaitable[None], Awaitable[NoReturn]]]
+RunPreProcessor = Callable[["Matcher", Bot, Event, dict], Awaitable[None]]
 """
-:类型: ``Callable[[Matcher, Bot, Event, dict], Union[Awaitable[None], Awaitable[NoReturn]]]``
+:类型: ``Callable[[Matcher, Bot, Event, dict], Awaitable[None]]``
 
 :说明:
 
   事件响应器运行前预处理函数 RunPreProcessor 类型
 """
 RunPostProcessor = Callable[["Matcher", Optional[Exception], Bot, Event, dict],
-                            Union[Awaitable[None], Awaitable[NoReturn]]]
+                            Awaitable[None]]
 """
-:类型: ``Callable[[Matcher, Optional[Exception], Bot, Event, dict], Union[Awaitable[None], Awaitable[NoReturn]]]``
+:类型: ``Callable[[Matcher, Optional[Exception], Bot, Event, dict], Awaitable[None]]``
 
 :说明:
 
@@ -177,19 +174,17 @@ PermissionChecker = Callable[[Bot, Event], Union[bool, Awaitable[bool]]]
 
   RuleChecker 即判断是否响应消息的处理函数。
 """
-Handler = Callable[[Bot, Event, dict], Union[Awaitable[None],
-                                             Awaitable[NoReturn]]]
+Handler = Callable[[Bot, Event, dict], Awaitable[None]]
 """
-:类型: ``Callable[[Bot, Event, dict], Union[Awaitable[None], Awaitable[NoReturn]]]``
+:类型: ``Callable[[Bot, Event, dict], Awaitable[None]]``
 
 :说明:
 
   Handler 即事件的处理函数。
 """
-ArgsParser = Callable[[Bot, Event, dict], Union[Awaitable[None],
-                                                Awaitable[NoReturn]]]
+ArgsParser = Callable[[Bot, Event, dict], Awaitable[None]]
 """
-:类型: ``Callable[[Bot, Event, dict], Union[Awaitable[None], Awaitable[NoReturn]]]``
+:类型: ``Callable[[Bot, Event, dict], Awaitable[None]]``
 
 :说明:
 


### PR DESCRIPTION
pylance报错
```
Cannot access member "register_adapter" for type "NoReturn"
  Member "register_adapter" is unknownPylance (reportGeneralTypeIssues)
```
mypy报错
```
Need type annotation for 'driver'mypy(error)
```
大概是NoReturn不能和其他联用
~是的没错我又在水PR~
