### PR TITLE
[Doc] Update: CQHTTP implementations rename

### DIFF
--- a/docs/api/matcher.md
+++ b/docs/api/matcher.md
@@ -47,6 +47,51 @@ sidebarDepth: 0
 
 
 
+### `plugin_name`
+
+
+* **类型**
+
+    `Optional[str]`
+
+
+
+* **说明**
+
+    事件响应器所在插件名
+
+
+
+### `module_name`
+
+
+* **类型**
+
+    `Optional[str]`
+
+
+
+* **说明**
+
+    事件响应器所在模块名
+
+
+
+### `module_prefix`
+
+
+* **类型**
+
+    `Optional[str]`
+
+
+
+* **说明**
+
+    事件响应器所在模块前缀
+
+
+
 ### `type`
 
 

--- a/docs/guide/cqhttp-guide.md
+++ b/docs/guide/cqhttp-guide.md
@@ -13,8 +13,8 @@ pip install nonebot-adapter-cqhttp
 QQ 协议端举例:
 
 - [go-cqhttp](https://github.com/Mrs4s/go-cqhttp) (基于 [MiraiGo](https://github.com/Mrs4s/MiraiGo))
-- [cqhttp-mirai-embedded](https://github.com/yyuueexxiinngg/cqhttp-mirai/tree/embedded)
-- [Mirai](https://github.com/mamoe/mirai) + [cqhttp-mirai](https://github.com/yyuueexxiinngg/cqhttp-mirai)
+- [onebot-kotlin](https://github.com/yyuueexxiinngg/onebot-kotlin)
+- [Mirai](https://github.com/mamoe/mirai) + [onebot-mirai](https://github.com/yyuueexxiinngg/onebot-kotlin)
 - [Mirai](https://github.com/mamoe/mirai) + [Mirai Native](https://github.com/iTXTech/mirai-native) + [CQHTTP](https://github.com/richardchien/coolq-http-api)
 - [OICQ-http-api](https://github.com/takayama-lily/onebot) (基于 [OICQ](https://github.com/takayama-lily/oicq))
 

--- a/docs/guide/cqhttp-guide.md
+++ b/docs/guide/cqhttp-guide.md
@@ -16,7 +16,7 @@ QQ 协议端举例:
 - [onebot-kotlin](https://github.com/yyuueexxiinngg/onebot-kotlin)
 - [Mirai](https://github.com/mamoe/mirai) + [onebot-mirai](https://github.com/yyuueexxiinngg/onebot-kotlin)
 - [Mirai](https://github.com/mamoe/mirai) + [Mirai Native](https://github.com/iTXTech/mirai-native) + [CQHTTP](https://github.com/richardchien/coolq-http-api)
-- [OICQ-http-api](https://github.com/takayama-lily/onebot) (基于 [OICQ](https://github.com/takayama-lily/oicq))
+- [oicq-plugin-onebot](https://github.com/takayama-lily/onebot) (基于 [abot](https://github.com/takayama-lily/abot) [OICQ](https://github.com/takayama-lily/oicq))
 
 这里以 [go-cqhttp](https://github.com/Mrs4s/go-cqhttp) 为例
 

--- a/docs/guide/cqhttp-guide.md
+++ b/docs/guide/cqhttp-guide.md
@@ -16,7 +16,7 @@ QQ 协议端举例:
 - [onebot-kotlin](https://github.com/yyuueexxiinngg/onebot-kotlin)
 - [Mirai](https://github.com/mamoe/mirai) + [onebot-mirai](https://github.com/yyuueexxiinngg/onebot-kotlin)
 - [Mirai](https://github.com/mamoe/mirai) + [Mirai Native](https://github.com/iTXTech/mirai-native) + [CQHTTP](https://github.com/richardchien/coolq-http-api)
-- [oicq-plugin-onebot](https://github.com/takayama-lily/onebot) (基于 [abot](https://github.com/takayama-lily/abot) [OICQ](https://github.com/takayama-lily/oicq))
+- [node-onebot](https://github.com/takayama-lily/node-onebot) (基于 [abot](https://github.com/takayama-lily/abot), [OICQ](https://github.com/takayama-lily/oicq))
 
 这里以 [go-cqhttp](https://github.com/Mrs4s/go-cqhttp) 为例
 


### PR DESCRIPTION
Update: cqhttp-mirai / cqhttp-mirai-embedded has been renamed to Onebot-Mirai / Onebot-Kotlin by its author [yyuueexxiinngg](https://github.com/yyuueexxiinngg). Since the embedded branch was abandoned, both links here point to master branch of [onebot-kotlin](https://github.com/yyuueexxiinngg/onebot-kotlin).