### PR TITLE
Fix exception raised when constructing `MessageChain` from string

### DIFF
--- a/packages/nonebot-adapter-mirai/nonebot/adapters/mirai/message.py
+++ b/packages/nonebot-adapter-mirai/nonebot/adapters/mirai/message.py
@@ -295,8 +295,7 @@ class MessageChain(BaseMessage[MessageSegment]):
         self, message: Union[List[Dict[str, Any]], Iterable[MessageSegment]]
     ) -> List[MessageSegment]:
         if isinstance(message, str):
-            raise ValueError(
-                "String operation is not supported in mirai adapter")
+            return [MessageSegment.plain(text=message)]
         return [
             *map(
                 lambda x: x


### PR DESCRIPTION
The incoming string will be defaulted to `MessageSegment.plain` type