### PR TITLE
Feature: support use `Message` object as message template

### DIFF
--- a/docs/api/adapters/README.md
+++ b/docs/api/adapters/README.md
@@ -305,7 +305,7 @@ await bot.send_msg(message="hello world")
 
 * **说明**
 
-    根据创建消息模板, 用法和 `str.format` 大致相同, 但是可以输出消息对象
+    根据创建消息模板, 用法和 `str.format` 大致相同, 但是可以输出消息对象, 并且支持以 `Message` 对象作为消息模板
 
 
 
@@ -317,6 +317,13 @@ await bot.send_msg(message="hello world")
 Message(MessageSegment(type='text', data={'text': 'hello world'}))
 >>> Message.template("{} {}").format(MessageSegment.image("file///..."), "world")
 Message(MessageSegment(type='image', data={'file': 'file///...'}), MessageSegment(type='text', data={'text': 'world'}))
+>>> Message.template(
+...       MessageSegment.text('test {event.user_id}') + MessageSegment.face(233) +
+...       MessageSegment.text('test {event.message}')).format(event={'user_id':123456, 'message':'hello world'}
+... )
+Message(MessageSegment(type='text', data={'text': 'test 123456'}), 
+        MessageSegment(type='face', data={'face': 233}), 
+        MessageSegment(type='text', data={'text': 'test hello world'}))
 ```
 
 

--- a/nonebot/adapters/_message.py
+++ b/nonebot/adapters/_message.py
@@ -103,11 +103,12 @@ class Message(List[TMS], abc.ABC):
             self.extend(self._construct(message))
 
     @classmethod
-    def template(cls: Type[TM], format_string: str) -> MessageTemplate[TM]:
+    def template(cls: Type[TM],
+                 format_string: Union[str, TM]) -> MessageTemplate[TM]:
         """
         :说明:
 
-          根据创建消息模板, 用法和 ``str.format`` 大致相同, 但是可以输出消息对象
+          根据创建消息模板, 用法和 ``str.format`` 大致相同, 但是可以输出消息对象, 并且支持以 ``Message`` 对象作为消息模板
 
         :示例:
 
@@ -117,6 +118,13 @@ class Message(List[TMS], abc.ABC):
             Message(MessageSegment(type='text', data={'text': 'hello world'}))
             >>> Message.template("{} {}").format(MessageSegment.image("file///..."), "world")
             Message(MessageSegment(type='image', data={'file': 'file///...'}), MessageSegment(type='text', data={'text': 'world'}))
+            >>> Message.template(
+            ...       MessageSegment.text('test {event.user_id}') + MessageSegment.face(233) +
+            ...       MessageSegment.text('test {event.message}')).format(event={'user_id':123456, 'message':'hello world'}
+            ... )
+            Message(MessageSegment(type='text', data={'text': 'test 123456'}), 
+                    MessageSegment(type='face', data={'face': 233}), 
+                    MessageSegment(type='text', data={'text': 'test hello world'}))
 
         :参数:
 

--- a/packages/nonebot-adapter-mirai/nonebot/adapters/mirai/message.py
+++ b/packages/nonebot-adapter-mirai/nonebot/adapters/mirai/message.py
@@ -275,22 +275,6 @@ class MessageChain(BaseMessage[MessageSegment]):
         return MessageSegment
 
     @overrides(BaseMessage)
-    def __init__(self, message: Union[List[Dict[str,
-                                                Any]], Iterable[MessageSegment],
-                                      MessageSegment, str], **kwargs):
-        super().__init__(**kwargs)
-        if isinstance(message, MessageSegment):
-            self.append(message)
-        elif isinstance(message, str):
-            self.append(MessageSegment.plain(text=message))
-        elif isinstance(message, Iterable):
-            self.extend(self._construct(message))
-        else:
-            raise ValueError(
-                f'Type {type(message).__name__} is not supported in mirai adapter.'
-            )
-
-    @overrides(BaseMessage)
     def _construct(
         self, message: Union[List[Dict[str, Any]], Iterable[MessageSegment]]
     ) -> List[MessageSegment]:


### PR DESCRIPTION
demo code (with mirai adapter):

```python
from nonebot.adapters.mirai import MessageEvent, Bot, MessageChain, MessageSegment
from nonebot.plugin import on_message

handler = on_message()


@handler.handle()
async def _(bot: Bot, event: MessageEvent, state: dict):
    await handler.send(MessageChain.template(
        MessageSegment.plain('test {event.source}') + MessageSegment.face(233) +
        MessageSegment.plain('test {event.message_chain}')).format(event=event),
                       at_sender=True)
```