### PR TITLE
Fix: `fastapi` 中轮询启用 `HTTP2` 的逻辑

### DIFF
--- a/nonebot/drivers/fastapi.py
+++ b/nonebot/drivers/fastapi.py
@@ -393,7 +393,7 @@ class Driver(ReverseDriver, ForwardDriver):
             f"Bot {escape_tag(setup.self_id)}</y>")
 
         try:
-            async with httpx.AsyncClient(http2=True) as session:
+            async with httpx.AsyncClient(http2=setup.http_version.startswith("2")) as session:
                 while not self.shutdown.is_set():
 
                     try:


### PR DESCRIPTION
resolved nonebot/adapter-telegram#3