### PR TITLE
:sparkles: Compatible with cross-platform superusers

### DIFF
--- a/nonebot/permission.py
+++ b/nonebot/permission.py
@@ -206,9 +206,10 @@ def USER(*users: str, perm: Optional[Permission] = None):
 
 class SuperUser:
     async def __call__(self, bot: Bot, event: Event) -> bool:
-        return (
-            event.get_type() == "message"
-            and event.get_user_id() in bot.config.superusers
+        return event.get_type() == "message" and (
+            f"{bot.adapter.get_name().split(maxsplit=1)[0].lower()}:{event.get_user_id()}"
+            in bot.config.superusers
+            or event.get_user_id() in bot.config.superusers  # 兼容旧配置
         )
 
 


### PR DESCRIPTION
Now you can use `onebot:1234567890` in superusers to specify the OneBot Adapter。

Of course it 's compatible with old superusers. For example: `1234567890` means users with user_id `1294567890` in all Adapters.