### PR TITLE
Remove mirai-api-http related info from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ _✨ 跨平台 Python 异步机器人框架 ✨_
   <a href="https://onebot.dev/">
     <img src="https://img.shields.io/badge/OneBot-v11-black?style=social&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABABAMAAABYR2ztAAAAIVBMVEUAAAAAAAADAwMHBwceHh4UFBQNDQ0ZGRkoKCgvLy8iIiLWSdWYAAAAAXRSTlMAQObYZgAAAQVJREFUSMftlM0RgjAQhV+0ATYK6i1Xb+iMd0qgBEqgBEuwBOxU2QDKsjvojQPvkJ/ZL5sXkgWrFirK4MibYUdE3OR2nEpuKz1/q8CdNxNQgthZCXYVLjyoDQftaKuniHHWRnPh2GCUetR2/9HsMAXyUT4/3UHwtQT2AggSCGKeSAsFnxBIOuAggdh3AKTL7pDuCyABcMb0aQP7aM4AnAbc/wHwA5D2wDHTTe56gIIOUA/4YYV2e1sg713PXdZJAuncdZMAGkAukU9OAn40O849+0ornPwT93rphWF0mgAbauUrEOthlX8Zu7P5A6kZyKCJy75hhw1Mgr9RAUvX7A3csGqZegEdniCx30c3agAAAABJRU5ErkJggg==" alt="cqhttp">
   </a>
-  <a href="http://github.com/mamoe/mirai">
-    <img src="https://img.shields.io/badge/mirai-HTTP-lightgrey?style=social">
-  </a>
   <a href="https://ding-doc.dingtalk.com/document#/org-dev-guide/elzz1p">
     <img src="https://img.shields.io/badge/%E9%92%89%E9%92%89-Bot-lightgrey?style=social&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAAnFBMVEUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD4jUzeAAAAM3RSTlMAQKSRaA+/f0YyFevh29R3cyklIfrlyrGsn41tVUs48c/HqJm9uZdhX1otGwkF9IN8V1CX0Q+IAAABY0lEQVRYw+3V2W7CMBAF0JuNQAhhX9OEfYdu9///rUVWpagE27Ef2gfO+0zGozsKnv6bMGzAhkNytIe5gDdzrwtTCwrbI8x4/NF668NAxgI3Q3UtFi3TyPwNQtPLUUmDd8YfqGLNe4v22XwEYb5zoOuF5baHq2UHtsKe5ivWfGAwrWu2mC34QM0PoCAuqZdOmiwV+5BLyMRtZ7dTSEcs48rzWfzwptMLyzpApka1SJ5FtR4kfCqNIBPEVDmqoqgwUYY5plQOlf6UEjNoOPnuKB6wzDyCrks///TDza8+PnR109WQdxLo8RKWq0PPnuXG0OXKQ6wWLFnCg75uYYbhmMIVVdQ709q33aHbGIj6Duz+2k1HQFX9VwqmY8xYsEJll2ahvhWgsjYLHFRXvIi2Qb0jzMQCzC3FAoydxCma88UCzE3JCWwkjCNYyMUCzHX4DiuTMawEwwhW6hnshPhjZzzJfAH0YacpbmRd7QAAAABJRU5ErkJggg==" alt="ding">
   </a>
@@ -80,7 +77,6 @@ NoneBot2 是一个现代、跨平台、可扩展的 Python 聊天机器人框架
 - 社区丰富：社区用户众多，直接和间接用户超过十万人，每天都有大量的活跃用户 ([社区资源](#社区资源))
 - 海纳百川：一个框架，支持多个聊天软件平台，可自定义通信协议
   - [OneBot 协议](https://onebot.dev/) (QQ 等)
-  - [Mirai-API-HTTP 协议](https://github.com/project-mirai/mirai-api-http)
   - [钉钉](https://ding-doc.dingtalk.com/document#/org-dev-guide/elzz1p)
   - [Telegram](https://core.telegram.org/bots/api)
   - [飞书](https://open.feishu.cn/document/home/index)

--- a/website/static/adapters.json
+++ b/website/static/adapters.json
@@ -20,16 +20,6 @@
     "is_official": true
   },
   {
-    "module_name": "nonebot.adapters.mirai",
-    "project_link": "nonebot-adapter-mirai",
-    "name": "mirai",
-    "desc": "Mirai-Api-HTTP 协议",
-    "author": "Mix",
-    "homepage": "https://github.com/nonebot/adapter-mirai",
-    "tags": [],
-    "is_official": true
-  },
-  {
     "module_name": "nonebot.adapters.feishu",
     "project_link": "nonebot-adapter-feishu",
     "name": "feishu",


### PR DESCRIPTION
Mirai-API-HTTP adapter will no longer be maintained by NoneBot officialy.