### PR TITLE
Plugin: 移除冷却事件插件

### DIFF
--- a/website/static/plugins.json
+++ b/website/static/plugins.json
@@ -144,16 +144,6 @@
     "is_official": false
   },
   {
-    "module_name": "nonebot_plugin_cooldown",
-    "project_link": "nonebot-plugin-cooldown",
-    "author": "jks15satoshi",
-    "desc": "为用户调用功能添加冷却时间（调用频率限制）功能",
-    "name": "冷却事件",
-    "homepage": "https://github.com/jks15satoshi/nonebot-plugin-cooldown",
-    "tags": [],
-    "is_official": false
-  },
-  {
     "module_name": "nonebot_plugin_mqtt",
     "project_link": "nonebot-plugin-mqtt",
     "author": "synodriver",


### PR DESCRIPTION
由于 OneBot v11 适配器自 v2.0.0b1 起提供了命令冷却支持，且该插件已无力继续维护，故将该插件从商店移除。