### PR TITLE
商店链接指向错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ NoneBot2 不是 NoneBot1 的替代品。事实上，它们都在被积极的维�
   - [文档镜像(中国境内)](https://nb2.baka.icu)
   - [文档镜像(Vercel)](https://nonebot2-vercel-mirror.vercel.app)
 
-- 其他插件请查看 [商店](https://v2.nonebot.dev/store.html)
+- 其他插件请查看 [商店](https://v2.nonebot.dev/store)
 
 ## 许可证
 


### PR DESCRIPTION
原商店链接（[https://v2.nonebot.dev/store.html](https://v2.nonebot.dev/store.html)）指向失效，正确链接应为[https://v2.nonebot.dev/store](https://v2.nonebot.dev/store)