### PR TITLE
👷checkout with PAT

### DIFF
--- a/.github/workflows/publish-bot.yml
+++ b/.github/workflows/publish-bot.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: NoneBot2 Publish Bot
         uses: nonebot/nonebot2-publish-bot@main


### PR DESCRIPTION
CI can be triggered when github action pushes a commit.