### PR TITLE
Plugin: 风格化字符串管理 商店信息更新

### DIFF
--- a/website/static/plugins.json
+++ b/website/static/plugins.json
@@ -186,7 +186,7 @@
   {
     "module_name": "nonebot-plugin-strman",
     "project_link": "nonebot-plugin-strman",
-    "author": "jks15satoshi",
+    "author": "echobot-dev",
     "desc": "通过字符串标签在文件中集中管理字符串",
     "name": "字符串管理工具",
     "homepage": "https://github.com/echobot-dev/nonebot-plugin-strman",

--- a/website/static/plugins.json
+++ b/website/static/plugins.json
@@ -184,12 +184,12 @@
     "is_official": false
   },
   {
-    "module_name": "nonebot_plugin_styledstr",
-    "project_link": "nonebot-plugin-styledstr",
+    "module_name": "nonebot-plugin-strman",
+    "project_link": "nonebot-plugin-strman",
     "author": "jks15satoshi",
-    "desc": "通过字符串标签管理字符串资源",
-    "name": "风格化字符串管理",
-    "homepage": "https://github.com/jks15satoshi/nonebot_plugin_styledstr",
+    "desc": "通过字符串标签在文件中集中管理字符串",
+    "name": "字符串管理工具",
+    "homepage": "https://github.com/echobot-dev/nonebot-plugin-strman",
     "tags": [],
     "is_official": false
   },


### PR DESCRIPTION
变更插件“风格化字符串管理”原始仓库已归档，该插件目前已迁移至仓库 [echobot-dev/nonebot-plugin-strman](https://github.com/echobot-dev/nonebot-plugin-strman) ，更名后重新在 PyPI 中发布。原插件商店信息需要更新，故提交 pr 修改。