### PR TITLE
Docs: 修改议题模板中的错误链接

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,11 +4,11 @@ contact_links:
     url: https://discussions.nonebot.dev/
     about: Ask questions about nonebot
   - name: Plugin Publish
-    url: https://v2.nonebot.dev/store.html
+    url: https://v2.nonebot.dev/store
     about: Publish your plugin to nonebot homepage and nb-cli
   - name: Adapter Publish
-    url: https://v2.nonebot.dev/store.html
+    url: https://v2.nonebot.dev/store
     about: Publish your adapter to nonebot homepage and nb-cli
   - name: Bot Publish
-    url: https://v2.nonebot.dev/store.html
+    url: https://v2.nonebot.dev/store
     about: Publish your bot to nonebot homepage and nb-cli


### PR DESCRIPTION
现在应该是 <https://v2.nonebot.dev/store> 。

<https://v2.nonebot.dev/store.html> 会提示 404。