### PR TITLE
Docs: 修复 ci/cd action 中错误的版本号

### DIFF
--- a/website/docs/tutorial/deployment.md
+++ b/website/docs/tutorial/deployment.md
@@ -162,7 +162,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: start deployment
-        uses: bobheadxi/deployments@v0.6
+        uses: bobheadxi/deployments@v0.6.2
         id: deployment
         with:
           step: start
@@ -185,7 +185,7 @@ jobs:
             docker-compose up -d
 
       - name: update deployment status
-        uses: bobheadxi/deployments@v0.6
+        uses: bobheadxi/deployments@v0.6.2
         if: always()
         with:
           step: finish


### PR DESCRIPTION
在 [github action](https://github.com/Bubbleioa/ioa-bot/runs/5250225969) 上出错 
Error: Unable to resolve action `bobheadxi/deployments@v0.6`, unable to find version `v0.6`

最新版本为 v0.6.2