### PR TITLE
add CommandStart and CommandToMe

### DIFF
--- a/nonebot/consts.py
+++ b/nonebot/consts.py
@@ -28,6 +28,8 @@ RAW_CMD_KEY: Literal["raw_command"] = "raw_command"
 """命令文本存储 key"""
 CMD_ARG_KEY: Literal["command_arg"] = "command_arg"
 """命令参数存储 key"""
+CMD_START_KEY: Literal["command_start"] = "command_start"
+"""命令开头存储 key"""
 
 SHELL_ARGS: Literal["_args"] = "_args"
 """shell 命令 parse 后参数字典存储 key"""

--- a/nonebot/params.py
+++ b/nonebot/params.py
@@ -33,6 +33,7 @@ from nonebot.consts import (
     RAW_CMD_KEY,
     REGEX_GROUP,
     REGEX_MATCHED,
+    CMD_START_KEY,
 )
 
 
@@ -97,6 +98,24 @@ def _command_arg(state: T_State) -> Message:
 def CommandArg() -> Any:
     """消息命令参数"""
     return Depends(_command_arg)
+
+
+def _command_start(state: T_State) -> str:
+    return state[PREFIX_KEY][CMD_START_KEY]
+
+
+def CommandStart() -> str:
+    """消息命令开头"""
+    return Depends(_command_start)
+
+
+def _command_to_me(event: Event, state: T_State) -> bool:
+    return event.is_tome() or bool(state[PREFIX_KEY][CMD_START_KEY])
+
+
+def CommandToMe() -> bool:
+    """`to_me` 或 存在 `command_start`"""
+    return Depends(_command_to_me)
 
 
 def _shell_command_args(state: T_State) -> Any:

--- a/tests/plugins/param/param_state.py
+++ b/tests/plugins/param/param_state.py
@@ -9,6 +9,7 @@ from nonebot.params import (
     RawCommand,
     RegexGroup,
     RegexMatched,
+    CommandStart,
     ShellCommandArgs,
     ShellCommandArgv,
 )
@@ -28,6 +29,10 @@ async def raw_command(raw_cmd: str = RawCommand()) -> str:
 
 async def command_arg(cmd_arg: Message = CommandArg()) -> Message:
     return cmd_arg
+
+
+async def command_start(start: str = CommandStart()) -> str:
+    return start
 
 
 async def shell_command_args(

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -123,6 +123,7 @@ async def test_state(app: App, load_plugin):
         RAW_CMD_KEY,
         REGEX_GROUP,
         REGEX_MATCHED,
+        CMD_START_KEY,
     )
     from plugins.param.param_state import (
         state,
@@ -132,13 +133,19 @@ async def test_state(app: App, load_plugin):
         raw_command,
         regex_group,
         regex_matched,
+        command_start,
         shell_command_args,
         shell_command_argv,
     )
 
     fake_message = make_fake_message()("text")
     fake_state = {
-        PREFIX_KEY: {CMD_KEY: ("cmd",), RAW_CMD_KEY: "/cmd", CMD_ARG_KEY: fake_message},
+        PREFIX_KEY: {
+            CMD_KEY: ("cmd",),
+            RAW_CMD_KEY: "/cmd",
+            CMD_START_KEY: "/",
+            CMD_ARG_KEY: fake_message,
+        },
         SHELL_ARGV: ["-h"],
         SHELL_ARGS: {"help": True},
         REGEX_MATCHED: "[cq:test,arg=value]",
@@ -167,6 +174,12 @@ async def test_state(app: App, load_plugin):
     ) as ctx:
         ctx.pass_params(state=fake_state)
         ctx.should_return(fake_state[PREFIX_KEY][CMD_ARG_KEY])
+
+    async with app.test_dependent(
+        command_start, allow_types=[StateParam, DependParam]
+    ) as ctx:
+        ctx.pass_params(state=fake_state)
+        ctx.should_return(fake_state[PREFIX_KEY][CMD_START_KEY])
 
     async with app.test_dependent(
         shell_command_argv, allow_types=[StateParam, DependParam]


### PR DESCRIPTION
添加 CommandStart，用于获得当前命令开头

这是为了添加 CommandToMe 规则，用于判断当前命令是否针对机器人，规则为 to_me 或者 当前命令开头不为空

这样如 remake 命令，既可以 `@机器人 remake` 也可以 `/remake`，单独的 `remake` 不会匹配