### PR TITLE
Feature: 添加 `RejectTimes` 依赖注入

### DIFF
--- a/nonebot/consts.py
+++ b/nonebot/consts.py
@@ -42,3 +42,6 @@ REGEX_GROUP: Literal["_matched_groups"] = "_matched_groups"
 """正则匹配 group 元组存储 key"""
 REGEX_DICT: Literal["_matched_dict"] = "_matched_dict"
 """正则匹配 group 字典存储 key"""
+
+REJECT_TIMES: Literal["_reject_times"] = "_reject_times"
+"""当前 `reject` 的次数"""

--- a/nonebot/internal/matcher.py
+++ b/nonebot/internal/matcher.py
@@ -18,13 +18,6 @@ from typing import (
 
 from nonebot.log import logger
 from nonebot.dependencies import Dependent
-from nonebot.consts import (
-    ARG_KEY,
-    RECEIVE_KEY,
-    REJECT_TARGET,
-    LAST_RECEIVE_KEY,
-    REJECT_CACHE_TARGET,
-)
 from nonebot.typing import (
     Any,
     T_State,
@@ -32,6 +25,14 @@ from nonebot.typing import (
     T_TypeUpdater,
     T_DependencyCache,
     T_PermissionUpdater,
+)
+from nonebot.consts import (
+    ARG_KEY,
+    RECEIVE_KEY,
+    REJECT_TIMES,
+    REJECT_TARGET,
+    LAST_RECEIVE_KEY,
+    REJECT_CACHE_TARGET,
 )
 from nonebot.exception import (
     TypeMisMatch,
@@ -671,6 +672,10 @@ class Matcher(metaclass=MatcherMeta):
             await self.resolve_reject()
             type_ = await self.update_type(bot, event)
             permission = await self.update_permission(bot, event)
+            if REJECT_TIMES in self.state:
+                self.state[REJECT_TIMES] += 1
+            else:
+                self.state[REJECT_TIMES] = 1
 
             Matcher.new(
                 type_,

--- a/nonebot/params.py
+++ b/nonebot/params.py
@@ -32,6 +32,7 @@ from nonebot.consts import (
     CMD_ARG_KEY,
     RAW_CMD_KEY,
     REGEX_GROUP,
+    REJECT_TIMES,
     CMD_START_KEY,
     REGEX_MATCHED,
 )
@@ -170,6 +171,14 @@ def LastReceived(default: Any = None) -> Any:
         return matcher.get_last_receive(default)
 
     return Depends(_last_received, use_cache=False)
+
+
+def _reject_times(state: T_State):
+    return state[REJECT_TIMES]
+
+
+def RejectTimes() -> int:
+    return Depends(_reject_times, use_cache=False)
 
 
 __autodoc__ = {

--- a/tests/plugins/param/param_state.py
+++ b/tests/plugins/param/param_state.py
@@ -8,6 +8,7 @@ from nonebot.params import (
     CommandArg,
     RawCommand,
     RegexGroup,
+    RejectTimes,
     CommandStart,
     RegexMatched,
     ShellCommandArgs,
@@ -65,3 +66,7 @@ async def regex_group(regex_group: Tuple = RegexGroup()) -> Tuple:
 
 async def regex_matched(regex_matched: str = RegexMatched()) -> str:
     return regex_matched
+
+
+async def reject_times(reject_times: int = RejectTimes()) -> int:
+    return reject_times

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -170,6 +170,7 @@ async def test_state(app: App, load_plugin):
         CMD_ARG_KEY,
         RAW_CMD_KEY,
         REGEX_GROUP,
+        REJECT_TIMES,
         CMD_START_KEY,
         REGEX_MATCHED,
     )
@@ -181,6 +182,7 @@ async def test_state(app: App, load_plugin):
         raw_command,
         regex_group,
         legacy_state,
+        reject_times,
         command_start,
         regex_matched,
         not_legacy_state,
@@ -201,6 +203,7 @@ async def test_state(app: App, load_plugin):
         REGEX_MATCHED: "[cq:test,arg=value]",
         REGEX_GROUP: ("test", "arg=value"),
         REGEX_DICT: {"type": "test", "arg": "value"},
+        REJECT_TIMES: 1,
     }
 
     async with app.test_dependent(state, allow_types=[StateParam]) as ctx:
@@ -270,6 +273,12 @@ async def test_state(app: App, load_plugin):
     ) as ctx:
         ctx.pass_params(state=fake_state)
         ctx.should_return(fake_state[REGEX_DICT])
+
+    async with app.test_dependent(
+        reject_times, allow_types=[StateParam, DependParam]
+    ) as ctx:
+        ctx.pass_params(state=fake_state)
+        ctx.should_return(fake_state[REJECT_TIMES])
 
 
 @pytest.mark.asyncio

--- a/website/docs/tutorial/plugin/create-handler.md
+++ b/website/docs/tutorial/plugin/create-handler.md
@@ -370,6 +370,20 @@ foo = on_message()
 async def _(matcher: Matcher): ...
 ```
 
+### RejectTimes
+
+获取当前 `reject` 的次数。
+
+```python {7}
+from nonebot import on_message
+from nonebot.params import RejectTimes
+
+matcher = on_message()
+
+@matcher.got("key")
+async def _(times: int = RejectTimes()): ...
+```
+
 ### Received
 
 获取某次 `receive` 接收的事件。


### PR DESCRIPTION
添加了 `RejectTimes`，用于获取当前 `reject` 的次数

使用例：

```python
from nonebot import on_command
from nonebot.params import RejectTimes

foo = on_command("reject")


@foo.got("", prompt="reject test")
async def _(times: int = RejectTimes()):
    if times <= 3:
        await foo.reject(str(times))
    else:
        await foo.finish("finish")
```

效果图（已经折叠）：

<details>
  <summary>展开</summary>
  
  ![image](https://user-images.githubusercontent.com/68982190/172854234-c2f25f3f-100f-4083-b290-451fbaffafee.png)

</details>
