### PR TITLE
Docs: 修改 `权限控制` 一节中主动调用的错误

### DIFF
--- a/website/docs/advanced/permission.md
+++ b/website/docs/advanced/permission.md
@@ -45,16 +45,16 @@ async def _():
 
 ```python
 from nonebot import on_command
-from nonebot.adapters.onebot.v11 import GroupMessageEvent
+from nonebot.adapters.onebot.v11 import Bot, GroupMessageEvent
 from nonebot.adapters.onebot.v11 import GROUP_ADMIN, GROUP_OWNER
 
 matcher = on_command("测试权限")
 
 @matcher.handle()
-async def _(event: GroupMessageEvent):
-    if await GROUP_ADMIN(event):
+async def _(bot: Bot, event: GroupMessageEvent):
+    if await GROUP_ADMIN(bot, event):
         await matcher.send("管理员测试成功")
-    elif await GROUP_OWNER(event):
+    elif await GROUP_OWNER(bot, event):
         await matcher.send("群主测试成功")
     else:
         await matcher.send("群员测试成功")


### PR DESCRIPTION
https://github.com/nonebot/nonebot2/blob/e2289c78b0161e6bc0f2d086eb9ca57789b7280f/nonebot/internal/permission.py#L50-L56

这里是要求至少传 `bot` 和 `event` 两个参数，但是文档的例子只传了 `event`，这里修改下