### PR TITLE
Feature: 使子依赖装饰器 depends 支持装饰器语法糖形式

### DIFF
--- a/nonebot/exception.py
+++ b/nonebot/exception.py
@@ -82,11 +82,12 @@ class SkippedException(ProcessException):
 
     用法:
         ```python
+        @depends
         def always_skip():
             Matcher.skip()
 
         @matcher.handle()
-        async def handler(dependency = Depends(always_skip)):
+        async def handler(dependency = always_skip):
             # never run
         ```
     """

--- a/nonebot/internal/matcher.py
+++ b/nonebot/internal/matcher.py
@@ -48,7 +48,6 @@ from .rule import Rule
 from .permission import USER, User, Permission
 from .adapter import Bot, Event, Message, MessageSegment, MessageTemplate
 from .params import (
-    Depends,
     ArgParam,
     BotParam,
     EventParam,
@@ -56,6 +55,7 @@ from .params import (
     DependParam,
     DefaultParam,
     MatcherParam,
+    depends,
 )
 
 if TYPE_CHECKING:
@@ -370,6 +370,7 @@ class Matcher(metaclass=MatcherMeta):
             parameterless: 非参数类型依赖列表
         """
 
+        @depends
         async def _receive(event: Event, matcher: "Matcher") -> Union[None, NoReturn]:
             matcher.set_target(RECEIVE_KEY.format(id=id))
             if matcher.get_target() == RECEIVE_KEY.format(id=id):
@@ -379,7 +380,7 @@ class Matcher(metaclass=MatcherMeta):
                 return
             await matcher.reject()
 
-        _parameterless = (Depends(_receive), *(parameterless or tuple()))
+        _parameterless = (_receive, *(parameterless or tuple()))
 
         def _decorator(func: T_Handler) -> T_Handler:
 
@@ -418,6 +419,7 @@ class Matcher(metaclass=MatcherMeta):
             parameterless: 非参数类型依赖列表
         """
 
+        @depends
         async def _key_getter(event: Event, matcher: "Matcher"):
             matcher.set_target(ARG_KEY.format(key=key))
             if matcher.get_target() == ARG_KEY.format(key=key):
@@ -427,7 +429,7 @@ class Matcher(metaclass=MatcherMeta):
                 return
             await matcher.reject(prompt)
 
-        _parameterless = (Depends(_key_getter), *(parameterless or tuple()))
+        _parameterless = (_key_getter, *(parameterless or tuple()))
 
         def _decorator(func: T_Handler) -> T_Handler:
 

--- a/nonebot/params.py
+++ b/nonebot/params.py
@@ -5,13 +5,13 @@ FrontMatter:
     description: nonebot.params 模块
 """
 
-from typing import Any, Dict, List, Tuple, Union, Optional
+from typing import Any, List, Union, Optional
 
 from nonebot.typing import T_State
 from nonebot.matcher import Matcher
 from nonebot.internal.params import Arg as Arg
 from nonebot.internal.params import ArgStr as ArgStr
-from nonebot.internal.params import Depends as Depends
+from nonebot.internal.params import depends as depends
 from nonebot.internal.params import ArgParam as ArgParam
 from nonebot.internal.params import BotParam as BotParam
 from nonebot.adapters import Event, Message, MessageSegment
@@ -36,145 +36,108 @@ from nonebot.consts import (
 )
 
 
-async def _event_type(event: Event) -> str:
+@depends
+async def event_type(event: Event) -> str:
+    """{ref}`nonebot.adapters.Event` 类型参数"""
     return event.get_type()
 
 
-def EventType() -> str:
-    """{ref}`nonebot.adapters.Event` 类型参数"""
-    return Depends(_event_type)
-
-
-async def _event_message(event: Event) -> Message:
+@depends
+async def event_message(event: Event) -> Message:
+    """{ref}`nonebot.adapters.Event` 消息参数"""
     return event.get_message()
 
 
-def EventMessage() -> Any:
-    """{ref}`nonebot.adapters.Event` 消息参数"""
-    return Depends(_event_message)
-
-
-async def _event_plain_text(event: Event) -> str:
+@depends
+async def event_plain_text(event: Event) -> str:
+    """{ref}`nonebot.adapters.Event` 纯文本消息参数"""
     return event.get_plaintext()
 
 
-def EventPlainText() -> str:
-    """{ref}`nonebot.adapters.Event` 纯文本消息参数"""
-    return Depends(_event_plain_text)
-
-
-async def _event_to_me(event: Event) -> bool:
+@depends
+async def event_to_me(event: Event) -> bool:
+    """{ref}`nonebot.adapters.Event` `to_me` 参数"""
     return event.is_tome()
 
 
-def EventToMe() -> bool:
-    """{ref}`nonebot.adapters.Event` `to_me` 参数"""
-    return Depends(_event_to_me)
-
-
-def _command(state: T_State) -> Message:
+@depends
+def command(state: T_State) -> Message:
+    """消息命令元组"""
     return state[PREFIX_KEY][CMD_KEY]
 
 
-def Command() -> Tuple[str, ...]:
-    """消息命令元组"""
-    return Depends(_command)
-
-
-def _raw_command(state: T_State) -> Message:
+@depends
+def raw_command(state: T_State) -> Message:
+    """消息命令文本"""
     return state[PREFIX_KEY][RAW_CMD_KEY]
 
 
-def RawCommand() -> str:
-    """消息命令文本"""
-    return Depends(_raw_command)
-
-
-def _command_arg(state: T_State) -> Message:
+@depends
+def command_arg(state: T_State) -> Message:
+    """消息命令参数"""
     return state[PREFIX_KEY][CMD_ARG_KEY]
 
 
-def CommandArg() -> Any:
-    """消息命令参数"""
-    return Depends(_command_arg)
-
-
-def _command_start(state: T_State) -> str:
+@depends
+def command_start(state: T_State) -> str:
+    """消息命令开头"""
     return state[PREFIX_KEY][CMD_START_KEY]
 
 
-def CommandStart() -> str:
-    """消息命令开头"""
-    return Depends(_command_start)
-
-
-def _shell_command_args(state: T_State) -> Any:
+@depends(use_cache=False)
+def shell_command_args(state: T_State) -> Any:
+    """shell 命令解析后的参数字典"""
     return state[SHELL_ARGS]  # Namespace or ParserExit
 
 
-def ShellCommandArgs() -> Any:
-    """shell 命令解析后的参数字典"""
-    return Depends(_shell_command_args, use_cache=False)
-
-
-def _shell_command_argv(state: T_State) -> List[Union[str, MessageSegment]]:
+@depends(use_cache=False)
+def shell_command_argv(state: T_State) -> List[Union[str, MessageSegment]]:
+    """shell 命令原始参数列表"""
     return state[SHELL_ARGV]
 
 
-def ShellCommandArgv() -> Any:
-    """shell 命令原始参数列表"""
-    return Depends(_shell_command_argv, use_cache=False)
-
-
-def _regex_matched(state: T_State) -> str:
+@depends(use_cache=False)
+def regex_matched(state: T_State) -> str:
+    """正则匹配结果"""
     return state[REGEX_MATCHED]
 
 
-def RegexMatched() -> str:
-    """正则匹配结果"""
-    return Depends(_regex_matched, use_cache=False)
-
-
-def _regex_group(state: T_State):
+@depends(use_cache=False)
+def regex_group(state: T_State):
+    """正则匹配结果 group 元组"""
     return state[REGEX_GROUP]
 
 
-def RegexGroup() -> Tuple[Any, ...]:
-    """正则匹配结果 group 元组"""
-    return Depends(_regex_group, use_cache=False)
-
-
-def _regex_dict(state: T_State):
+@depends(use_cache=False)
+def regex_dict(state: T_State):
+    """正则匹配结果 group 字典"""
     return state[REGEX_DICT]
 
 
-def RegexDict() -> Dict[str, Any]:
-    """正则匹配结果 group 字典"""
-    return Depends(_regex_dict, use_cache=False)
-
-
-def Received(id: Optional[str] = None, default: Any = None) -> Any:
+def received(id: Optional[str] = None, default: Any = None) -> Any:
     """`receive` 事件参数"""
 
+    @depends(use_cache=False)
     def _received(matcher: "Matcher"):
         return matcher.get_receive(id or "", default)
 
-    return Depends(_received, use_cache=False)
+    return _received
 
 
-def LastReceived(default: Any = None) -> Any:
+def last_received(default: Any = None) -> Any:
     """`last_receive` 事件参数"""
 
+    @depends(use_cache=False)
     def _last_received(matcher: "Matcher") -> Any:
         return matcher.get_last_receive(default)
 
-    return Depends(_last_received, use_cache=False)
+    return _last_received
 
 
 __autodoc__ = {
     "Arg": True,
     "ArgStr": True,
-    "Depends": True,
+    "depends": True,
     "ArgParam": True,
     "BotParam": True,
     "EventParam": True,

--- a/nonebot/permission.py
+++ b/nonebot/permission.py
@@ -8,7 +8,7 @@ FrontMatter:
     description: nonebot.permission 模块
 """
 
-from nonebot.params import EventType
+from nonebot.params import event_type
 from nonebot.adapters import Bot, Event
 from nonebot.internal.permission import USER as USER
 from nonebot.internal.permission import User as User
@@ -20,7 +20,7 @@ class Message:
 
     __slots__ = ()
 
-    async def __call__(self, type: str = EventType()) -> bool:
+    async def __call__(self, type: str = event_type()) -> bool:
         return type == "message"
 
 
@@ -29,7 +29,7 @@ class Notice:
 
     __slots__ = ()
 
-    async def __call__(self, type: str = EventType()) -> bool:
+    async def __call__(self, type: str = event_type()) -> bool:
         return type == "notice"
 
 
@@ -38,7 +38,7 @@ class Request:
 
     __slots__ = ()
 
-    async def __call__(self, type: str = EventType()) -> bool:
+    async def __call__(self, type: str = event_type()) -> bool:
         return type == "request"
 
 
@@ -47,7 +47,7 @@ class MetaEvent:
 
     __slots__ = ()
 
-    async def __call__(self, type: str = EventType()) -> bool:
+    async def __call__(self, type: str = event_type()) -> bool:
         return type == "meta_event"
 
 

--- a/nonebot/plugins/echo.py
+++ b/nonebot/plugins/echo.py
@@ -1,11 +1,11 @@
 from nonebot.rule import to_me
 from nonebot.adapters import Message
-from nonebot.params import CommandArg
 from nonebot.plugin import on_command
+from nonebot.params import command_arg
 
 echo = on_command("echo", to_me())
 
 
 @echo.handle()
-async def echo_escape(message: Message = CommandArg()):
+async def echo_escape(message: Message = command_arg()):
     await echo.send(message=message)

--- a/nonebot/plugins/single_session.py
+++ b/nonebot/plugins/single_session.py
@@ -7,7 +7,6 @@ from nonebot.message import IgnoredException, event_preprocessor
 _running_matcher: Dict[str, int] = {}
 
 
-@depends
 async def matcher_mutex(event: Event) -> AsyncGenerator[bool, None]:
     result = False
     try:
@@ -26,6 +25,6 @@ async def matcher_mutex(event: Event) -> AsyncGenerator[bool, None]:
 
 
 @event_preprocessor
-async def preprocess(mutex: bool = matcher_mutex):
+async def preprocess(mutex: bool = depends(matcher_mutex)):
     if mutex:
         raise IgnoredException("Another matcher running")

--- a/nonebot/plugins/single_session.py
+++ b/nonebot/plugins/single_session.py
@@ -15,7 +15,8 @@ async def matcher_mutex(event: Event) -> AsyncGenerator[bool, None]:
         yield result
     else:
         current_event_id = id(event)
-        if event_id := _running_matcher.get(session_id, None):
+        event_id = _running_matcher.get(session_id, None)
+        if event_id:
             result = event_id != current_event_id
         else:
             _running_matcher[session_id] = current_event_id

--- a/nonebot/rule.py
+++ b/nonebot/rule.py
@@ -39,14 +39,14 @@ from nonebot.log import logger
 from nonebot.typing import T_State
 from nonebot.exception import ParserExit
 from nonebot.internal.rule import Rule as Rule
+from nonebot.params import command as command_param
 from nonebot.adapters import Bot, Event, Message, MessageSegment
 from nonebot.params import (
-    Command,
-    EventToMe,
-    EventType,
-    CommandArg,
-    EventMessage,
-    EventPlainText,
+    event_type,
+    command_arg,
+    event_to_me,
+    event_message,
+    event_plain_text,
 )
 from nonebot.consts import (
     CMD_KEY,
@@ -144,7 +144,7 @@ class StartswithRule:
         return hash((frozenset(self.msg), self.ignorecase))
 
     async def __call__(
-        self, type: str = EventType(), text: str = EventPlainText()
+        self, type: str = event_type(), text: str = event_plain_text()
     ) -> Any:
         if type != "message":
             return False
@@ -198,7 +198,7 @@ class EndswithRule:
         return hash((frozenset(self.msg), self.ignorecase))
 
     async def __call__(
-        self, type: str = EventType(), text: str = EventPlainText()
+        self, type: str = event_type(), text: str = event_plain_text()
     ) -> Any:
         if type != "message":
             return False
@@ -252,7 +252,7 @@ class FullmatchRule:
         return hash((frozenset(self.msg), self.ignorecase))
 
     async def __call__(
-        self, type_: str = EventType(), text: str = EventPlainText()
+        self, type_: str = event_type(), text: str = event_plain_text()
     ) -> bool:
         return (
             type_ == "message"
@@ -297,7 +297,7 @@ class KeywordsRule:
         return hash(frozenset(self.keywords))
 
     async def __call__(
-        self, type: str = EventType(), text: str = EventPlainText()
+        self, type: str = event_type(), text: str = event_plain_text()
     ) -> bool:
         if type != "message":
             return False
@@ -337,7 +337,7 @@ class CommandRule:
     def __hash__(self) -> int:
         return hash((frozenset(self.cmds),))
 
-    async def __call__(self, cmd: Optional[Tuple[str, ...]] = Command()) -> bool:
+    async def __call__(self, cmd: Optional[Tuple[str, ...]] = command_param()) -> bool:
         return cmd in self.cmds
 
 
@@ -347,9 +347,9 @@ def command(*cmds: Union[str, Tuple[str, ...]]) -> Rule:
     根据配置里提供的 {ref}``command_start` <nonebot.config.Config.command_start>`,
     {ref}``command_sep` <nonebot.config.Config.command_sep>` 判断消息是否为命令。
 
-    可以通过 {ref}`nonebot.params.Command` 获取匹配成功的命令（例: `("test",)`），
-    通过 {ref}`nonebot.params.RawCommand` 获取匹配成功的原始命令文本（例: `"/test"`），
-    通过 {ref}`nonebot.params.CommandArg` 获取匹配成功的命令参数。
+    可以通过 {ref}`nonebot.params.command` 获取匹配成功的命令（例: `("test",)`），
+    通过 {ref}`nonebot.params.raw_command` 获取匹配成功的原始命令文本（例: `"/test"`），
+    通过 {ref}`nonebot.params.command_arg` 获取匹配成功的命令参数。
 
     参数:
         cmds: 命令文本或命令元组
@@ -469,8 +469,8 @@ class ShellCommandRule:
     async def __call__(
         self,
         state: T_State,
-        cmd: Optional[Tuple[str, ...]] = Command(),
-        msg: Optional[Message] = CommandArg(),
+        cmd: Optional[Tuple[str, ...]] = command_param(),
+        msg: Optional[Message] = command_arg(),
     ) -> bool:
         if cmd not in self.cmds or msg is None:
             return False
@@ -501,13 +501,13 @@ def shell_command(
     根据配置里提供的 {ref}``command_start` <nonebot.config.Config.command_start>`,
     {ref}``command_sep` <nonebot.config.Config.command_sep>` 判断消息是否为命令。
 
-    可以通过 {ref}`nonebot.params.Command` 获取匹配成功的命令（例: `("test",)`），
-    通过 {ref}`nonebot.params.RawCommand` 获取匹配成功的原始命令文本（例: `"/test"`），
-    通过 {ref}`nonebot.params.ShellCommandArgv` 获取解析前的参数列表（例: `["arg", "-h"]`），
-    通过 {ref}`nonebot.params.ShellCommandArgs` 获取解析后的参数字典（例: `{"arg": "arg", "h": True}`）。
+    可以通过 {ref}`nonebot.params.command` 获取匹配成功的命令（例: `("test",)`），
+    通过 {ref}`nonebot.params.raw_command` 获取匹配成功的原始命令文本（例: `"/test"`），
+    通过 {ref}`nonebot.params.shell_command_argv` 获取解析前的参数列表（例: `["arg", "-h"]`），
+    通过 {ref}`nonebot.params.shell_command_args` 获取解析后的参数字典（例: `{"arg": "arg", "h": True}`）。
 
     :::warning 警告
-    如果参数解析失败，则通过 {ref}`nonebot.params.ShellCommandArgs`
+    如果参数解析失败，则通过 {ref}`nonebot.params.shell_command_args`
     获取的将是 {ref}`nonebot.exception.ParserExit` 异常。
     :::
 
@@ -586,8 +586,8 @@ class RegexRule:
     async def __call__(
         self,
         state: T_State,
-        type: str = EventType(),
-        msg: Message = EventMessage(),
+        type: str = event_type(),
+        msg: Message = event_message(),
     ) -> bool:
         if type != "message":
             return False
@@ -604,9 +604,9 @@ class RegexRule:
 def regex(regex: str, flags: Union[int, re.RegexFlag] = 0) -> Rule:
     """匹配符合正则表达式的消息字符串。
 
-    可以通过 {ref}`nonebot.params.RegexMatched` 获取匹配成功的字符串，
-    通过 {ref}`nonebot.params.RegexGroup` 获取匹配成功的 group 元组，
-    通过 {ref}`nonebot.params.RegexDict` 获取匹配成功的 group 字典。
+    可以通过 {ref}`nonebot.params.regex_matched` 获取匹配成功的字符串，
+    通过 {ref}`nonebot.params.regex_group` 获取匹配成功的 group 元组，
+    通过 {ref}`nonebot.params.regex_dict` 获取匹配成功的 group 字典。
 
     参数:
         regex: 正则表达式
@@ -638,7 +638,7 @@ class ToMeRule:
     def __hash__(self) -> int:
         return hash((self.__class__,))
 
-    async def __call__(self, to_me: bool = EventToMe()) -> bool:
+    async def __call__(self, to_me: bool = event_to_me()) -> bool:
         return to_me
 
 

--- a/tests/examples/weather.py
+++ b/tests/examples/weather.py
@@ -2,13 +2,13 @@ from nonebot import on_command
 from nonebot.rule import to_me
 from nonebot.matcher import Matcher
 from nonebot.adapters import Message
-from nonebot.params import Arg, CommandArg, ArgPlainText
+from nonebot.params import Arg, ArgPlainText, command_arg
 
 weather = on_command("weather", rule=to_me(), aliases={"天气", "天气预报"}, priority=5)
 
 
 @weather.handle()
-async def handle_first_receive(matcher: Matcher, args: Message = CommandArg()):
+async def handle_first_receive(matcher: Matcher, args: Message = command_arg()):
     plain_text = args.extract_plain_text()  # 首次发送命令时跟随的参数，例：/天气 上海，则args为上海
     if plain_text:
         matcher.set_arg("city", args)  # 如果用户发送了参数则直接赋值

--- a/tests/plugins/matcher/matcher_process.py
+++ b/tests/plugins/matcher/matcher_process.py
@@ -1,7 +1,7 @@
 from nonebot import on_message
 from nonebot.matcher import Matcher
 from nonebot.adapters import Event, Message
-from nonebot.params import ArgStr, Received, EventMessage, LastReceived
+from nonebot.params import ArgStr, received, event_message, last_received
 
 test_handle = on_message()
 
@@ -30,7 +30,7 @@ test_receive = on_message()
 @test_receive.receive()
 @test_receive.receive("receive")
 async def receive(
-    x: Event = Received("receive"), y: Event = LastReceived(), z: Event = Received()
+    x: Event = received("receive"), y: Event = last_received(), z: Event = received()
 ):
     assert str(x.get_message()) == "text"
     assert str(z.get_message()) == "text"
@@ -44,7 +44,7 @@ test_combine = on_message()
 @test_combine.got("a")
 @test_combine.receive()
 @test_combine.got("b")
-async def combine(a: str = ArgStr(), b: str = ArgStr(), r: Event = Received()):
+async def combine(a: str = ArgStr(), b: str = ArgStr(), r: Event = received()):
     if a == "text":
         await test_combine.reject_arg("a")
     elif b == "text":
@@ -61,7 +61,7 @@ test_preset = on_message()
 
 
 @test_preset.handle()
-async def preset(matcher: Matcher, message: Message = EventMessage()):
+async def preset(matcher: Matcher, message: Message = event_message()):
     matcher.set_arg("a", message)
 
 

--- a/tests/plugins/param/param_depend.py
+++ b/tests/plugins/param/param_depend.py
@@ -1,49 +1,53 @@
 from dataclasses import dataclass
 
 from nonebot import on_message
-from nonebot.params import Depends
+from nonebot.params import depends
 
 test_depends = on_message()
 
 runned = []
 
 
+@depends
 def dependency():
     runned.append(1)
     return 1
 
 
+@depends
 def parameterless():
     assert len(runned) == 0
     runned.append(1)
 
 
+@depends
 def gen_sync():
     yield 1
 
 
+@depends
 async def gen_async():
     yield 2
 
 
 @dataclass
 class ClassDependency:
-    x: int = Depends(gen_sync)
-    y: int = Depends(gen_async)
+    x: int = gen_sync
+    y: int = gen_async
 
 
 # test parameterless
-@test_depends.handle(parameterless=[Depends(parameterless)])
-async def depends(x: int = Depends(dependency)):
+@test_depends.handle(parameterless=[parameterless])
+async def depend(x: int = dependency):
     # test dependency
     return x
 
 
 @test_depends.handle()
-async def depends_cache(y: int = Depends(dependency, use_cache=True)):
+async def depends_cache(y: int = dependency(use_cache=True)):
     # test cache
     return y
 
 
-async def class_depend(c: ClassDependency = Depends()):
+async def class_depend(c: ClassDependency = depends()):
     return c

--- a/tests/plugins/param/param_depend.py
+++ b/tests/plugins/param/param_depend.py
@@ -38,7 +38,7 @@ class ClassDependency:
 
 # test parameterless
 @test_depends.handle(parameterless=[parameterless])
-async def depend(x: int = dependency):
+async def depends_test(x: int = dependency):
     # test dependency
     return x
 

--- a/tests/plugins/param/param_event.py
+++ b/tests/plugins/param/param_event.py
@@ -1,7 +1,7 @@
 from typing import Union
 
 from nonebot.adapters import Event, Message
-from nonebot.params import EventToMe, EventType, EventMessage, EventPlainText
+from nonebot.params import event_type, event_to_me, event_message, event_plain_text
 
 
 async def event(e: Event) -> Event:
@@ -36,17 +36,17 @@ async def not_event(e: Union[int, Event]):
     ...
 
 
-async def event_type(t: str = EventType()) -> str:
+async def event_type_test(t: str = event_type()) -> str:
     return t
 
 
-async def event_message(msg: Message = EventMessage()) -> Message:
+async def event_message_test(msg: Message = event_message()) -> Message:
     return msg
 
 
-async def event_plain_text(text: str = EventPlainText()) -> str:
+async def event_plain_text_test(text: str = event_plain_text()) -> str:
     return text
 
 
-async def event_to_me(to_me: bool = EventToMe()) -> bool:
+async def event_to_me_test(to_me: bool = event_to_me()) -> bool:
     return to_me

--- a/tests/plugins/param/param_matcher.py
+++ b/tests/plugins/param/param_matcher.py
@@ -1,15 +1,15 @@
 from nonebot.adapters import Event
 from nonebot.matcher import Matcher
-from nonebot.params import Received, LastReceived
+from nonebot.params import received, last_received
 
 
 async def matcher(m: Matcher) -> Matcher:
     return m
 
 
-async def receive(e: Event = Received("test")) -> Event:
+async def receive_test(e: Event = received("test")) -> Event:
     return e
 
 
-async def last_receive(e: Event = LastReceived()) -> Event:
+async def last_receive_test(e: Event = last_received()) -> Event:
     return e

--- a/tests/plugins/param/param_state.py
+++ b/tests/plugins/param/param_state.py
@@ -3,15 +3,15 @@ from typing import List, Tuple
 from nonebot.typing import T_State
 from nonebot.adapters import Message
 from nonebot.params import (
-    Command,
-    RegexDict,
-    CommandArg,
-    RawCommand,
-    RegexGroup,
-    CommandStart,
-    RegexMatched,
-    ShellCommandArgs,
-    ShellCommandArgv,
+    command,
+    regex_dict,
+    command_arg,
+    raw_command,
+    regex_group,
+    command_start,
+    regex_matched,
+    shell_command_args,
+    shell_command_argv,
 )
 
 
@@ -27,41 +27,41 @@ async def not_legacy_state(state: int):
     ...
 
 
-async def command(cmd: Tuple[str, ...] = Command()) -> Tuple[str, ...]:
+async def command_test(cmd: Tuple[str, ...] = command()) -> Tuple[str, ...]:
     return cmd
 
 
-async def raw_command(raw_cmd: str = RawCommand()) -> str:
+async def raw_command_test(raw_cmd: str = raw_command()) -> str:
     return raw_cmd
 
 
-async def command_arg(cmd_arg: Message = CommandArg()) -> Message:
+async def command_arg_test(cmd_arg: Message = command_arg()) -> Message:
     return cmd_arg
 
 
-async def command_start(start: str = CommandStart()) -> str:
+async def command_start_test(start: str = command_start()) -> str:
     return start
 
 
-async def shell_command_args(
-    shell_command_args: dict = ShellCommandArgs(),
+async def shell_command_args_test(
+    shell_command_args: dict = shell_command_args(),
 ) -> dict:
     return shell_command_args
 
 
-async def shell_command_argv(
-    shell_command_argv: List[str] = ShellCommandArgv(),
+async def shell_command_argv_test(
+    shell_command_argv: List[str] = shell_command_argv(),
 ) -> List[str]:
     return shell_command_argv
 
 
-async def regex_dict(regex_dict: dict = RegexDict()) -> dict:
+async def regex_dict_test(regex_dict: dict = regex_dict()) -> dict:
     return regex_dict
 
 
-async def regex_group(regex_group: Tuple = RegexGroup()) -> Tuple:
+async def regex_group_test(regex_group: Tuple = regex_group()) -> Tuple:
     return regex_group
 
 
-async def regex_matched(regex_matched: str = RegexMatched()) -> str:
+async def regex_matched_test(regex_matched: str = regex_matched()) -> str:
     return regex_matched

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -10,12 +10,12 @@ async def test_depend(app: App, load_plugin):
     from plugins.param.param_depend import (
         ClassDependency,
         runned,
-        depends,
         class_depend,
+        depends_test,
         test_depends,
     )
 
-    async with app.test_dependent(depends, allow_types=[DependParam]) as ctx:
+    async with app.test_dependent(depends_test, allow_types=[DependParam]) as ctx:
         ctx.should_return(1)
 
     assert len(runned) == 1 and runned[0] == 1
@@ -90,13 +90,13 @@ async def test_event(app: App, load_plugin):
         event,
         not_event,
         sub_event,
-        event_type,
-        event_to_me,
         union_event,
         legacy_event,
-        event_message,
-        event_plain_text,
+        event_type_test,
+        event_to_me_test,
         not_legacy_event,
+        event_message_test,
+        event_plain_text_test,
     )
 
     fake_message = make_fake_message()("text")
@@ -134,25 +134,25 @@ async def test_event(app: App, load_plugin):
             ...
 
     async with app.test_dependent(
-        event_type, allow_types=[EventParam, DependParam]
+        event_type_test, allow_types=[EventParam, DependParam]
     ) as ctx:
         ctx.pass_params(event=fake_event)
         ctx.should_return(fake_event.get_type())
 
     async with app.test_dependent(
-        event_message, allow_types=[EventParam, DependParam]
+        event_message_test, allow_types=[EventParam, DependParam]
     ) as ctx:
         ctx.pass_params(event=fake_event)
         ctx.should_return(fake_event.get_message())
 
     async with app.test_dependent(
-        event_plain_text, allow_types=[EventParam, DependParam]
+        event_plain_text_test, allow_types=[EventParam, DependParam]
     ) as ctx:
         ctx.pass_params(event=fake_event)
         ctx.should_return(fake_event.get_plaintext())
 
     async with app.test_dependent(
-        event_to_me, allow_types=[EventParam, DependParam]
+        event_to_me_test, allow_types=[EventParam, DependParam]
     ) as ctx:
         ctx.pass_params(event=fake_event)
         ctx.should_return(fake_event.is_tome())
@@ -175,17 +175,17 @@ async def test_state(app: App, load_plugin):
     )
     from plugins.param.param_state import (
         state,
-        command,
-        regex_dict,
-        command_arg,
-        raw_command,
-        regex_group,
+        command_test,
         legacy_state,
-        command_start,
-        regex_matched,
+        regex_dict_test,
+        command_arg_test,
         not_legacy_state,
-        shell_command_args,
-        shell_command_argv,
+        raw_command_test,
+        regex_group_test,
+        command_start_test,
+        regex_matched_test,
+        shell_command_args_test,
+        shell_command_argv_test,
     )
 
     fake_message = make_fake_message()("text")
@@ -218,55 +218,55 @@ async def test_state(app: App, load_plugin):
             ...
 
     async with app.test_dependent(
-        command, allow_types=[StateParam, DependParam]
+        command_test, allow_types=[StateParam, DependParam]
     ) as ctx:
         ctx.pass_params(state=fake_state)
         ctx.should_return(fake_state[PREFIX_KEY][CMD_KEY])
 
     async with app.test_dependent(
-        raw_command, allow_types=[StateParam, DependParam]
+        raw_command_test, allow_types=[StateParam, DependParam]
     ) as ctx:
         ctx.pass_params(state=fake_state)
         ctx.should_return(fake_state[PREFIX_KEY][RAW_CMD_KEY])
 
     async with app.test_dependent(
-        command_arg, allow_types=[StateParam, DependParam]
+        command_arg_test, allow_types=[StateParam, DependParam]
     ) as ctx:
         ctx.pass_params(state=fake_state)
         ctx.should_return(fake_state[PREFIX_KEY][CMD_ARG_KEY])
 
     async with app.test_dependent(
-        command_start, allow_types=[StateParam, DependParam]
+        command_start_test, allow_types=[StateParam, DependParam]
     ) as ctx:
         ctx.pass_params(state=fake_state)
         ctx.should_return(fake_state[PREFIX_KEY][CMD_START_KEY])
 
     async with app.test_dependent(
-        shell_command_argv, allow_types=[StateParam, DependParam]
+        shell_command_argv_test, allow_types=[StateParam, DependParam]
     ) as ctx:
         ctx.pass_params(state=fake_state)
         ctx.should_return(fake_state[SHELL_ARGV])
 
     async with app.test_dependent(
-        shell_command_args, allow_types=[StateParam, DependParam]
+        shell_command_args_test, allow_types=[StateParam, DependParam]
     ) as ctx:
         ctx.pass_params(state=fake_state)
         ctx.should_return(fake_state[SHELL_ARGS])
 
     async with app.test_dependent(
-        regex_matched, allow_types=[StateParam, DependParam]
+        regex_matched_test, allow_types=[StateParam, DependParam]
     ) as ctx:
         ctx.pass_params(state=fake_state)
         ctx.should_return(fake_state[REGEX_MATCHED])
 
     async with app.test_dependent(
-        regex_group, allow_types=[StateParam, DependParam]
+        regex_group_test, allow_types=[StateParam, DependParam]
     ) as ctx:
         ctx.pass_params(state=fake_state)
         ctx.should_return(fake_state[REGEX_GROUP])
 
     async with app.test_dependent(
-        regex_dict, allow_types=[StateParam, DependParam]
+        regex_dict_test, allow_types=[StateParam, DependParam]
     ) as ctx:
         ctx.pass_params(state=fake_state)
         ctx.should_return(fake_state[REGEX_DICT])
@@ -276,7 +276,7 @@ async def test_state(app: App, load_plugin):
 async def test_matcher(app: App, load_plugin):
     from nonebot.matcher import Matcher
     from nonebot.params import DependParam, MatcherParam
-    from plugins.param.param_matcher import matcher, receive, last_receive
+    from plugins.param.param_matcher import matcher, receive_test, last_receive_test
 
     fake_matcher = Matcher()
 
@@ -290,13 +290,13 @@ async def test_matcher(app: App, load_plugin):
     fake_matcher.set_receive("", event_next)
 
     async with app.test_dependent(
-        receive, allow_types=[MatcherParam, DependParam]
+        receive_test, allow_types=[MatcherParam, DependParam]
     ) as ctx:
         ctx.pass_params(matcher=fake_matcher)
         ctx.should_return(event)
 
     async with app.test_dependent(
-        last_receive, allow_types=[MatcherParam, DependParam]
+        last_receive_test, allow_types=[MatcherParam, DependParam]
     ) as ctx:
         ctx.pass_params(matcher=fake_matcher)
         ctx.should_return(event_next)


### PR DESCRIPTION
## 描述
使子依赖装饰器 depends 支持装饰器语法糖形式

**在这之前**
```python
def depend_func() -> Any:
    return ...

def depend_gen_func():
    try:
        yield ...
    finally:
        ...

async def handler(param_name: Any = Depends(depend_func), gen: Any = Depends(depend_gen_func)):
```

**在这之后**
```python
@depends
def depend_func() -> Any:
    return ...

@depends(use_cache=False)
def depend_gen_func():
    try:
        yield ...
    finally:
        ...

async def handler(param_name: Any = depend_func, gen: Any = depend_gen_func):
    ...
```

## 类型
- [x] 破坏性变更

## 为什么这样做？

### 1. 更高的区分度
想象一下, 依赖函数与普通函数混在同一个文件中
```python
def a():
    ...

def b():
    ...

def c():
    ...

async def handler(pa: Any = Depends(a), pc: Any = Depends(c)):
    b()
```
如何分辨普通函数与依赖函数呢？这可能得看到事件处理函数才能确定。
那如果使用装饰器语法糖会怎么样？
```python
@depends
def a():
    ...

def b():
    ...

@depends
def c():
    ...

async def handler(pa: Any = a, pc: Any = c):
    b()
```
一目了然，我们仅需要看到 depends 装饰器，就能确定它是一个依赖函数。

### 2. 去除大量的重复性代码
让我们看下面这样一个例子
```python
def a():
    ...

def b():
    ...

def c():
    ...

async def handler1(pa: Any = Depends(a), pb: Any = Depends(b), pc: Any = Depends(c)):
    ...

async def handler2(pb: Any = Depends(b)):
    ...
```
这些重复的 Depends 是冗余的，我们应该消除这种冗余，让代码变得更简洁。
就像下面这样
```python
@depends
def a():
    ...

@depends
def b():
    ...

@depends
def c():
    ...

async def handler1(pa: Any = a, pb: Any = b, pc: Any = c):
    ...

async def handler2(pb: Any = b):
    ...
```
哪怕这个依赖函数被再多的事件处理函数使用，它也只需要被装饰一次就够了。