### PR TITLE
修复matcher.get_arg返回非Message类型导致的错误

### DIFF
--- a/nonebot/internal/matcher.py
+++ b/nonebot/internal/matcher.py
@@ -610,7 +610,11 @@ class Matcher(metaclass=MatcherMeta):
 
         如果没有找到对应的消息，返回 `default` 值
         """
-        return self.state.get(ARG_KEY.format(key=key), default)
+        _ = self.state.get(ARG_KEY.format(key=key), default)
+        if isinstance(_, Message) or isinstance(_, default):
+            return _
+        else:
+            return Message(_)
 
     def set_arg(self, key: str, message: Message) -> None:
         """设置一个 `got` 消息"""

--- a/nonebot/internal/params.py
+++ b/nonebot/internal/params.py
@@ -327,6 +327,8 @@ class ArgParam(Param):
         message = matcher.get_arg(self.extra["key"])
         if message is None:
             return message
+        if isinstance(message, str):
+            return message
         if self.extra["type"] == "message":
             return message
         elif self.extra["type"] == "str":


### PR DESCRIPTION
Matcher.get_arg在某些情况下返回非Message类型 #1270 