### PR TITLE
Feature: 使用 `importlib.metadata` 替换 `pkg_resources`

### DIFF
--- a/nonebot/__init__.py
+++ b/nonebot/__init__.py
@@ -39,7 +39,7 @@ FrontMatter:
 
 import os
 import importlib
-from importlib.metadata import distribution
+from importlib.metadata import version
 from typing import Any, Dict, Type, Optional
 
 import loguru
@@ -52,8 +52,7 @@ from nonebot.config import Env, Config
 from nonebot.drivers import Driver, ReverseDriver, combine_driver
 
 try:
-    _dist = distribution("nonebot2")
-    __version__ = _dist.version
+    __version__ = version("nonebot2")
 except Exception:  # pragma: no cover
     __version__ = None
 

--- a/nonebot/__init__.py
+++ b/nonebot/__init__.py
@@ -39,6 +39,7 @@ FrontMatter:
 
 import os
 import importlib
+from importlib.metadata import version
 from typing import Any, Dict, Type, Optional
 
 import loguru
@@ -50,15 +51,7 @@ from nonebot.utils import escape_tag
 from nonebot.config import Env, Config
 from nonebot.drivers import Driver, ReverseDriver, combine_driver
 
-try:
-    import pkg_resources
-
-    _dist: pkg_resources.Distribution = pkg_resources.get_distribution("nonebot2")
-    __version__ = _dist.version
-    VERSION = _dist.parsed_version
-except Exception:  # pragma: no cover
-    __version__ = None
-    VERSION = None
+__version__ = version("nonebot2")
 
 _driver: Optional[Driver] = None
 

--- a/nonebot/__init__.py
+++ b/nonebot/__init__.py
@@ -39,7 +39,7 @@ FrontMatter:
 
 import os
 import importlib
-from importlib.metadata import version
+from importlib.metadata import distribution
 from typing import Any, Dict, Type, Optional
 
 import loguru
@@ -51,7 +51,11 @@ from nonebot.utils import escape_tag
 from nonebot.config import Env, Config
 from nonebot.drivers import Driver, ReverseDriver, combine_driver
 
-__version__ = version("nonebot2")
+try:
+    _dist = distribution("nonebot2")
+    __version__ = _dist.version
+except Exception:  # pragma: no cover
+    __version__ = None
 
 _driver: Optional[Driver] = None
 


### PR DESCRIPTION
> importlib.metadata 是一个提供对已安装包的元数据访问的库。这个库部分建立在 Python 的导入系统上，旨在取代 pkg_resources 的 [entry point API](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points) 和 [metadata API](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#metadata-api) 中的类似功能。 通过和 Python 3.7 或更高版本中的 [importlib.resources](https://docs.python.org/zh-cn/3.8/library/importlib.html#module-importlib.resources) 一同使用（对于旧版本的 Python 则作为 [importlib_resources](https://importlib-resources.readthedocs.io/en/latest/index.html) 向后移植），这可以消除对使用较旧且较为低效的 pkg_resources 包的需要。

移除对setuptools的依赖，移除变量`nonebot.VERSION`支持，自行使用`packaging.version.parse`