### PR TITLE
Fix: Bot `__getattr__` 不再对 `__xxx__` 方法返回

### DIFF
--- a/nonebot/internal/adapter/bot.py
+++ b/nonebot/internal/adapter/bot.py
@@ -44,7 +44,9 @@ class Bot(abc.ABC):
 
     def __getattr__(self, name: str) -> "_ApiCall":
         if name.startswith("__") and name.endswith("__"):
-            raise AttributeError
+            raise AttributeError(
+                f"'{self.__class__.__name__}' object has no attribute '{name}'"
+            )
         return partial(self.call_api, name)
 
     @property

--- a/nonebot/internal/adapter/bot.py
+++ b/nonebot/internal/adapter/bot.py
@@ -43,6 +43,8 @@ class Bot(abc.ABC):
         return f"Bot(type={self.type!r}, self_id={self.self_id!r})"
 
     def __getattr__(self, name: str) -> "_ApiCall":
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError
         return partial(self.call_api, name)
 
     @property


### PR DESCRIPTION
不要截胡魔术方法，不然可能发生坏事