### PR TITLE
Docs: 修正文档中部分配置文件示例的符号误用

### DIFF
--- a/website/docs/tutorial/configuration.md
+++ b/website/docs/tutorial/configuration.md
@@ -224,8 +224,8 @@ NICKNAME=["bot"]
 命令消息的起始符和分隔符。用于 [`command`](../api/rule.md#command) 规则。
 
 ```env
-COMMAND_START={"/", "!"}
-COMMAND_SEP={".", "/"}
+COMMAND_START=["/", "!"]
+COMMAND_SEP=[".", "/"]
 ```
 
 ### Session Expire Timeout

--- a/website/versioned_docs/version-2.0.0rc2/tutorial/configuration.md
+++ b/website/versioned_docs/version-2.0.0rc2/tutorial/configuration.md
@@ -224,8 +224,8 @@ NICKNAME=["bot"]
 命令消息的起始符和分隔符。用于 [`command`](../api/rule.md#command) 规则。
 
 ```env
-COMMAND_START={"/", "!"}
-COMMAND_SEP={".", "/"}
+COMMAND_START=["/", "!"]
+COMMAND_SEP=[".", "/"]
 ```
 
 ### Session Expire Timeout


### PR DESCRIPTION
Command Start 和 Command Separator 代码块里面是大括号