### PR TITLE
Feature:  `REGEX_MATCHED` 值由`matched.group()` 改为 `matched`

### DIFF
--- a/nonebot/params.py
+++ b/nonebot/params.py
@@ -5,6 +5,7 @@ FrontMatter:
     description: nonebot.params 模块
 """
 
+from re import Match
 from typing import Any, Dict, List, Tuple, Union, Optional
 
 from nonebot.typing import T_State
@@ -130,11 +131,11 @@ def ShellCommandArgv() -> Any:
     return Depends(_shell_command_argv, use_cache=False)
 
 
-def _regex_matched(state: T_State) -> str:
+def _regex_matched(state: T_State) -> Match[str]:
     return state[REGEX_MATCHED]
 
 
-def RegexMatched() -> str:
+def RegexMatched() -> Match[str]:
     """正则匹配结果"""
     return Depends(_regex_matched, use_cache=False)
 

--- a/nonebot/params.py
+++ b/nonebot/params.py
@@ -5,8 +5,7 @@ FrontMatter:
     description: nonebot.params 模块
 """
 
-from re import Match
-from typing import Any, Dict, List, Tuple, Union, Optional
+from typing import Any, Dict, List, Match, Tuple, Union, Optional
 
 from nonebot.typing import T_State
 from nonebot.matcher import Matcher

--- a/nonebot/rule.py
+++ b/nonebot/rule.py
@@ -615,7 +615,7 @@ class RegexRule:
         except Exception:
             return False
         if matched := re.search(self.regex, str(msg), self.flags):
-            state[REGEX_MATCHED] = matched.group()
+            state[REGEX_MATCHED] = matched
             state[REGEX_GROUP] = matched.groups()
             state[REGEX_DICT] = matched.groupdict()
             return True
@@ -626,7 +626,7 @@ class RegexRule:
 def regex(regex: str, flags: Union[int, re.RegexFlag] = 0) -> Rule:
     """匹配符合正则表达式的消息字符串。
 
-    可以通过 {ref}`nonebot.params.RegexMatched` 获取匹配成功的字符串，
+    可以通过 {ref}`nonebot.params.RegexMatched` 获取匹配成功的 Match 对象，
     通过 {ref}`nonebot.params.RegexGroup` 获取匹配成功的 group 元组，
     通过 {ref}`nonebot.params.RegexDict` 获取匹配成功的 group 字典。
 

--- a/tests/plugins/param/param_state.py
+++ b/tests/plugins/param/param_state.py
@@ -1,3 +1,4 @@
+from re import Match
 from typing import List, Tuple
 
 from nonebot.typing import T_State
@@ -67,7 +68,7 @@ async def regex_group(regex_group: Tuple = RegexGroup()) -> Tuple:
     return regex_group
 
 
-async def regex_matched(regex_matched: str = RegexMatched()) -> str:
+async def regex_matched(regex_matched: Match[str] = RegexMatched()) -> Match[str]:
     return regex_matched
 
 

--- a/tests/plugins/param/param_state.py
+++ b/tests/plugins/param/param_state.py
@@ -1,5 +1,4 @@
-from re import Match
-from typing import List, Tuple
+from typing import List, Match, Tuple
 
 from nonebot.typing import T_State
 from nonebot.adapters import Message

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from nonebug import App
 
@@ -206,7 +208,7 @@ async def test_state(app: App, load_plugin):
         },
         SHELL_ARGV: ["-h"],
         SHELL_ARGS: {"help": True},
-        REGEX_MATCHED: "[cq:test,arg=value]",
+        REGEX_MATCHED: re.search(r"", "[cq:test,arg=value]"),
         REGEX_GROUP: ("test", "arg=value"),
         REGEX_DICT: {"type": "test", "arg": "value"},
         STARTSWITH_KEY: "startswith",

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1,6 +1,6 @@
 import re
 import sys
-from typing import Dict, Tuple, Union, Optional
+from typing import Dict, Match, Tuple, Union, Optional
 
 import pytest
 from nonebug import App
@@ -350,7 +350,7 @@ async def test_regex(
     type: str,
     text: Optional[str],
     expected: bool,
-    matched: Optional[re.Match[str]],
+    matched: Optional[Match[str]],
     group: Optional[Tuple[str, ...]],
     dict: Optional[Dict[str, str]],
 ):

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from typing import Dict, Tuple, Union, Optional
 
@@ -335,7 +336,7 @@ async def test_shell_command(app: App):
             "message",
             "_key1_",
             True,
-            "key1",
+            re.search(r"(?P<key>key\d)", "_key1_"),
             ("key1",),
             {"key": "key1"},
         ),
@@ -349,7 +350,7 @@ async def test_regex(
     type: str,
     text: Optional[str],
     expected: bool,
-    matched: Optional[str],
+    matched: Optional[re.Match[str]],
     group: Optional[Tuple[str, ...]],
     dict: Optional[Dict[str, str]],
 ):
@@ -368,7 +369,7 @@ async def test_regex(
     event = make_fake_event(_type=type, _message=message)()
     state = {}
     assert await dependent(event=event, state=state) == expected
-    assert state.get(REGEX_MATCHED) == matched
+    assert str(state.get(REGEX_MATCHED)) == str(matched)
     assert state.get(REGEX_GROUP) == group
     assert state.get(REGEX_DICT) == dict
 

--- a/website/docs/tutorial/plugin/create-handler.md
+++ b/website/docs/tutorial/plugin/create-handler.md
@@ -328,7 +328,7 @@ async def _(foo: List[Union[str, MessageSegment]] = ShellCommandArgv()): ...
 ```python {7}
 from nonebot import on_regex
 from nonebot.params import RegexMatched
-from re import Match
+from typing import Match
 
 matcher = on_regex("regex")
 

--- a/website/docs/tutorial/plugin/create-handler.md
+++ b/website/docs/tutorial/plugin/create-handler.md
@@ -328,11 +328,12 @@ async def _(foo: List[Union[str, MessageSegment]] = ShellCommandArgv()): ...
 ```python {7}
 from nonebot import on_regex
 from nonebot.params import RegexMatched
+from re import Match
 
 matcher = on_regex("regex")
 
 @matcher.handle()
-async def _(foo: str = RegexMatched()): ...
+async def _(foo: Match[str] = RegexMatched()): ...
 ```
 
 ### RegexGroup


### PR DESCRIPTION
## 描述

将 `REGEX_MATCHED` 的值由`matched.group()` 改为 `matched`，即：使用 Match 对象代替原本的字符串

## 动机和背景

目前 nb2 中正则匹配结果只有：
- 匹配文本
- 匹配元组
- 匹配字典

这三种类型，相对后两者而言，匹配文本的用途过于稀少。

同时，由于 nb2 中没有提供获取 匹配对象 的方法，导致一些属性无法取得，比如：
- start() : 匹配字符串在给定字符串的开始位置下标
- end() : 匹配字符串在给定字符串的结束位置下标
- span() : 返回一个元组类型，包含开始位置下标和结束位置下标

这些 匹配对象 的属性，无法正常取得。

并且，由于匹配对象的[ `__getitem__` 方法](https://docs.python.org/zh-cn/3/library/re.html?highlight=Match#re.Match.__getitem__)，可以做到替代 匹配元组 或 匹配字典 来使用。

因此，建议使用功能性更强的 匹配对象 代替原本的 匹配文本