### PR TITLE
Docs: 修复文档中部分超链接跳转到 /store.html 的问题

### DIFF
--- a/website/docs/advanced/publish-plugin.md
+++ b/website/docs/advanced/publish-plugin.md
@@ -32,7 +32,7 @@ options:
 
 ### 申请发布到 NoneBot2 插件商店
 
-完成在 PyPI 的插件发布流程与源代码托管流程后，请您前往 [**NoneBot2 商店**](https://v2.nonebot.dev/store.html)页面，切换到**插件**页签，点击**发布插件**按钮。
+完成在 PyPI 的插件发布流程与源代码托管流程后，请您前往 [**NoneBot2 商店**](https://v2.nonebot.dev/store)页面，切换到**插件**页签，点击**发布插件**按钮。
 
 ![插件发布界面](./images/plugin_store_publish.png)
 
@@ -61,12 +61,12 @@ import 包名：您的插件通过 Python 导入时使用的包名，如 nonebot
 
 之后，NoneBot2 的维护者们将会对插件进行进一步的检查，以确保用户能够正常安装并使用该插件。
 
-完成这些步骤后，您的插件将会被合并到 [**NoneBot2 商店**](https://v2.nonebot.dev/store.html)，而您也将成为 [**NoneBot2 贡献者**](https://github.com/nonebot/nonebot2/graphs/contributors)中的一员。
+完成这些步骤后，您的插件将会被合并到 [**NoneBot2 商店**](https://v2.nonebot.dev/store)，而您也将成为 [**NoneBot2 贡献者**](https://github.com/nonebot/nonebot2/graphs/contributors)中的一员。
 
 ## 完成
 
 恭喜您，经过上述的发布流程，您的插件已经成功发布到 NoneBot2 商店了。
 
-此时，您可以在 [**NoneBot2 商店**](https://v2.nonebot.dev/store.html)的插件页签查找到您的插件。同时，欢迎您成为 [**NoneBot2 贡献者**](https://github.com/nonebot/nonebot2/graphs/contributors)！
+此时，您可以在 [**NoneBot2 商店**](https://v2.nonebot.dev/store)的插件页签查找到您的插件。同时，欢迎您成为 [**NoneBot2 贡献者**](https://github.com/nonebot/nonebot2/graphs/contributors)！
 
 **Congratulations!**

--- a/website/versioned_docs/version-2.0.0rc2/advanced/publish-plugin.md
+++ b/website/versioned_docs/version-2.0.0rc2/advanced/publish-plugin.md
@@ -32,7 +32,7 @@ options:
 
 ### 申请发布到 NoneBot2 插件商店
 
-完成在 PyPI 的插件发布流程与源代码托管流程后，请您前往 [**NoneBot2 商店**](https://v2.nonebot.dev/store.html)页面，切换到**插件**页签，点击**发布插件**按钮。
+完成在 PyPI 的插件发布流程与源代码托管流程后，请您前往 [**NoneBot2 商店**](https://v2.nonebot.dev/store)页面，切换到**插件**页签，点击**发布插件**按钮。
 
 ![插件发布界面](./images/plugin_store_publish.png)
 
@@ -61,12 +61,12 @@ import 包名：您的插件通过 Python 导入时使用的包名，如 nonebot
 
 之后，NoneBot2 的维护者们将会对插件进行进一步的检查，以确保用户能够正常安装并使用该插件。
 
-完成这些步骤后，您的插件将会被合并到 [**NoneBot2 商店**](https://v2.nonebot.dev/store.html)，而您也将成为 [**NoneBot2 贡献者**](https://github.com/nonebot/nonebot2/graphs/contributors)中的一员。
+完成这些步骤后，您的插件将会被合并到 [**NoneBot2 商店**](https://v2.nonebot.dev/store)，而您也将成为 [**NoneBot2 贡献者**](https://github.com/nonebot/nonebot2/graphs/contributors)中的一员。
 
 ## 完成
 
 恭喜您，经过上述的发布流程，您的插件已经成功发布到 NoneBot2 商店了。
 
-此时，您可以在 [**NoneBot2 商店**](https://v2.nonebot.dev/store.html)的插件页签查找到您的插件。同时，欢迎您成为 [**NoneBot2 贡献者**](https://github.com/nonebot/nonebot2/graphs/contributors)！
+此时，您可以在 [**NoneBot2 商店**](https://v2.nonebot.dev/store)的插件页签查找到您的插件。同时，欢迎您成为 [**NoneBot2 贡献者**](https://github.com/nonebot/nonebot2/graphs/contributors)！
 
 **Congratulations!**


### PR DESCRIPTION
在 文档 `进阶`-> `发布插件` 中，有三处 `Nonebot商店` 指向 `/store.html`，分别位于:

- [申请发布到 NoneBot2 插件商店](https://v2.nonebot.dev/docs/advanced/publish-plugin#%E7%94%B3%E8%AF%B7%E5%8F%91%E5%B8%83%E5%88%B0-nonebot2-%E6%8F%92%E4%BB%B6%E5%95%86%E5%BA%97)
- [等待插件发布处理](https://v2.nonebot.dev/docs/advanced/publish-plugin#%E7%AD%89%E5%BE%85%E6%8F%92%E4%BB%B6%E5%8F%91%E5%B8%83%E5%A4%84%E7%90%86)
- [完成](https://v2.nonebot.dev/docs/advanced/publish-plugin#%E5%AE%8C%E6%88%90)  

其会导致部分用户从此页无法进入正确的商店页面，
而在 `开始` -> `安装第三方插件` 中，对商店的指向链接是正确的。

本请求将相关链接修改为了 `/store`，希望对贵项目有所帮助

以上