### PR TITLE
CI: 添加插件加载测试

### DIFF
--- a/.github/workflows/publish-bot.yml
+++ b/.github/workflows/publish-bot.yml
@@ -16,9 +16,10 @@ jobs:
       result: ${{ steps.plugin-test.outputs.RESULT }}
       output: ${{ steps.plugin-test.outputs.OUTPUT }}
     steps:
-      - name: Install poetry
+      - name: Install Poetry
         run: pipx install poetry
-      - uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Test Plugin
@@ -31,11 +32,10 @@ jobs:
     name: nonebot2 publish bot
     needs: plugin_test
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_TOKEN }}
-
       - name: NoneBot2 Publish Bot
         uses: docker://ghcr.io/nonebot/nonebot2-publish-bot:main
         with:

--- a/.github/workflows/publish-bot.yml
+++ b/.github/workflows/publish-bot.yml
@@ -7,9 +7,29 @@ on:
     types: [closed]
 
 jobs:
+  plugin_test:
+    runs-on: ubuntu-latest
+    name: nonebot2 plugin test
+    permissions:
+      issues: read
+    outputs:
+      result: ${{ steps.plugin-test.outputs.RESULT }}
+      output: ${{ steps.plugin-test.outputs.OUTPUT }}
+    steps:
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Test Plugin
+        id: plugin-test
+        run: |
+          curl -sSL https://raw.githubusercontent.com/nonebot/nonebot2-publish-bot/main/plugin_test.py -o plugin_test.py
+          python plugin_test.py
   publish_bot:
     runs-on: ubuntu-latest
     name: nonebot2 publish bot
+    needs: plugin_test
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -27,3 +47,6 @@ jobs:
               "bot_path": "website/static/bots.json",
               "adapter_path": "website/static/adapters.json"
             }
+        env:
+          PLUGIN_TEST_RESULT: ${{ needs.plugin_test.outputs.result }}
+          PLUGIN_TEST_OUTPUT: ${{ needs.plugin_test.outputs.output }}

--- a/.github/workflows/publish-bot.yml
+++ b/.github/workflows/publish-bot.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, reopened, edited]
   pull_request_target:
     types: [closed]
+  issue_comment:
+    types: [created]
 
 jobs:
   plugin_test:


### PR DESCRIPTION
在 Linux, Python 3.10 环境下测试插件加载情况。

并且可通过评论 `/skip` 跳过插件测试。