### PR TITLE
Docs: pip 安装指令添加引号

### DIFF
--- a/website/versioned_docs/version-2.0.0rc3/start/installation.mdx
+++ b/website/versioned_docs/version-2.0.0rc3/start/installation.mdx
@@ -56,9 +56,9 @@ nb-cli 的使用方法详见[使用脚手架](./nb-cli.md)
 如果你不想使用脚手架，可以直接安装 NoneBot2，并自行完成开发配置。
 
 ```bash
-pip install nonebot2[fastapi]
+pip install 'nonebot2[fastapi]'
 # 也可以通过 Poetry 安装
-poetry add nonebot2[fastapi]
+poetry add 'nonebot2[fastapi]'
 ```
 
 ## 从 GitHub 安装


### PR DESCRIPTION
加上单引号让bash/zsh识别成普通字符串