### PR TITLE
Add support for PEP-593 `Annotated` for specifying dependencies

### DIFF
--- a/tests/plugins/param/param_depend.py
+++ b/tests/plugins/param/param_depend.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing_extensions import Annotated
 
 from nonebot import on_message
 from nonebot.params import Depends
@@ -47,3 +48,7 @@ async def depends_cache(y: int = Depends(dependency, use_cache=True)):
 
 async def class_depend(c: ClassDependency = Depends()):
     return c
+
+
+async def annotated_depend(x: Annotated[int, Depends(dependency)]):
+    return x

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -41,6 +41,7 @@ async def test_depend(app: App):
         runned,
         depends,
         class_depend,
+        annotated_depend,
         test_depends,
     )
 
@@ -62,6 +63,11 @@ async def test_depend(app: App):
 
     async with app.test_dependent(class_depend, allow_types=[DependParam]) as ctx:
         ctx.should_return(ClassDependency(x=1, y=2))
+
+    async with app.test_dependent(annotated_depend, allow_types=[DependParam]) as ctx:
+        ctx.should_return(1)
+
+    assert runned == [1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Example

### Before

```python
@handler1.handle()
async def _(user:User=Depends(current_user)):
	...

@handler2.handle()
async def _(user:User=Depends(current_user)):
	...

@handler3.handle()
async def _(user:User=Depends(current_user)):
	...
```

### After

```python
CurrentUser = Annotated[User, Depends(current_user)]

@handler1.handle()
async def _(user:CurrentUser):
	...

@handler2.handle()
async def _(user:CurrentUser):
	...

@handler3.handle()
async def _(user:CurrentUser):
	...
```

## References:

- https://github.com/tiangolo/fastapi/commit/375513f11494bc3499050ad2a0d378fb6e37ca98
- https://github.com/tiangolo/fastapi/releases/tag/0.95.0
- https://peps.python.org/pep-0593/
- https://docs.python.org/3/library/typing.html#typing.Annotated