### PR TITLE
Plugin: 移除 `MC_QQ_MCRcon`

### DIFF
--- a/website/static/plugins.json
+++ b/website/static/plugins.json
@@ -2278,25 +2278,6 @@
     "is_official": false
   },
   {
-    "module_name": "nonebot_plugin_mcqq_mcrcon",
-    "project_link": "nonebot-plugin-mcqq-mcrcon",
-    "name": "MC_QQ_MCRcon",
-    "desc": "基于NoneBot的QQ群聊与Minecraft Server消息互通插件",
-    "author": "17TheWord",
-    "homepage": "https://github.com/17TheWord/nonebot-plugin-mcqq",
-    "tags": [
-      {
-        "label": "Minecraft",
-        "color": "#4aea7a"
-      },
-      {
-        "label": "消息互通",
-        "color": "#32ddea"
-      }
-    ],
-    "is_official": false
-  },
-  {
     "module_name": "nonebot_plugin_gsmaterial",
     "project_link": "nonebot-plugin-gsmaterial",
     "name": "原神每日材料查询",


### PR DESCRIPTION
插件 nonebot-plugin-mcqq 与 nonebot-plugin-mcqq-mcrcon 已合并为 nonebot-plugin-mcqq