### PR TITLE
修复获取事件信息文档代码范例中缺失的 import.mdx

### DIFF
--- a/website/versioned_docs/version-2.0.0rc4/tutorial/event-data.mdx
+++ b/website/versioned_docs/version-2.0.0rc4/tutorial/event-data.mdx
@@ -28,6 +28,7 @@ import Messenger from "@site/src/components/Messenger";
 
 ```python {8,10} title=weather/__init__.py
 from nonebot import on_command
+from nonebot.rule import to_me
 from nonebot.adapters import Message
 from nonebot.params import CommandArg
 


### PR DESCRIPTION
📝 Docs: 修正教程中部分 import 缺失的问题 (#1980)