### PR TITLE
Docs: 修复事件处理函数文档代码范例中缺失的 import

### DIFF
--- a/website/versioned_docs/version-2.0.0rc4/tutorial/handler.mdx
+++ b/website/versioned_docs/version-2.0.0rc4/tutorial/handler.mdx
@@ -26,9 +26,9 @@ import Messenger from "@site/src/components/Messenger";
 
 顾名思义，“事件处理函数装饰器”是一个[装饰器（decorator）](https://docs.python.org/zh-cn/3/glossary.html#term-decorator)，那么它的使用方法也同[函数定义](https://docs.python.org/zh-cn/3/reference/compound_stmts.html#function-definitions)中所展示的包装用法相同。例如：
 
-```python {5-7} title=weather/__init__.py
-from nonebot.plugin import on_command
+```python {6-8} title=weather/__init__.py
 from nonebot.rule import to_me
+from nonebot.plugin import on_command
 
 weather = on_command("天气", rule=to_me(), aliases={"weather", "查天气"}, priority=10, block=True)
 

--- a/website/versioned_docs/version-2.0.0rc4/tutorial/handler.mdx
+++ b/website/versioned_docs/version-2.0.0rc4/tutorial/handler.mdx
@@ -28,6 +28,7 @@ import Messenger from "@site/src/components/Messenger";
 
 ```python {5-7} title=weather/__init__.py
 from nonebot.plugin import on_command
+from nonebot.rule import to_me
 
 weather = on_command("天气", rule=to_me(), aliases={"weather", "查天气"}, priority=10, block=True)
 


### PR DESCRIPTION
📝 Docs: 修复获取事件信息文档代码范例中缺失的 import (# 1982)