### PR TITLE
Docs: 修复获取事件信息文档代码范例中的高亮行

### DIFF
--- a/website/versioned_docs/version-2.0.0rc4/tutorial/event-data.mdx
+++ b/website/versioned_docs/version-2.0.0rc4/tutorial/event-data.mdx
@@ -26,7 +26,7 @@ import Messenger from "@site/src/components/Messenger";
 
 例如，我们可以继续改进上一章节中的 `weather` 插件，使其可以获取到 `天气` 命令的地名参数，并根据地名返回天气信息。
 
-```python {8,10} title=weather/__init__.py
+```python {9,11} title=weather/__init__.py
 from nonebot import on_command
 from nonebot.rule import to_me
 from nonebot.adapters import Message


### PR DESCRIPTION
📝 Docs: 修复获取事件信息文档代码范例中的高亮行（# 1983）