### PR TITLE
补测试，修bug(?

### DIFF
--- a/nonebot/internal/driver/model.py
+++ b/nonebot/internal/driver/model.py
@@ -125,7 +125,7 @@ class Request:
             files_ = files.items() if isinstance(files, dict) else files
             for name, file_info in files_:
                 if not isinstance(file_info, tuple):
-                    self.files.append((name, (None, file_info, None)))
+                    self.files.append((name, (name, file_info, None)))
                 elif len(file_info) == 2:
                     self.files.append((name, (file_info[0], file_info[1], None)))
                 else:

--- a/tests/plugins/matcher/matcher_check.py
+++ b/tests/plugins/matcher/matcher_check.py
@@ -1,0 +1,28 @@
+from nonebot.internal.matcher import Matcher
+from nonebot.internal.permission import Permission
+from nonebot.internal.rule import Rule
+
+
+async def bad():
+    _ = 1 / 0
+    return True
+
+
+async def falsy():
+    return False
+
+
+def to_falsy_rule_matcher(handle):
+    return Matcher.new(handlers=[handle], rule=Rule(falsy))
+
+
+def to_bad_rule_matcher(handle):
+    return Matcher.new(handlers=[handle], rule=Rule(bad))
+
+
+def to_falsy_perm_matcher(handle):
+    return Matcher.new(handlers=[handle], permission=Permission(falsy))
+
+
+def to_bad_perm_matcher(handle):
+    return Matcher.new(handlers=[handle], permission=Permission(bad))

--- a/tests/plugins/matcher/matcher_check.py
+++ b/tests/plugins/matcher/matcher_check.py
@@ -1,6 +1,6 @@
+from nonebot.internal.rule import Rule
 from nonebot.internal.matcher import Matcher
 from nonebot.internal.permission import Permission
-from nonebot.internal.rule import Rule
 
 
 async def bad():

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -238,14 +238,16 @@ async def test_http_client(driver: Driver, server_url: URL):
             server_url.scheme.encode("ascii"),
             server_url.host.encode("ascii"),
             server_url.port,
-            server_url.path.encode("ascii")
+            server_url.path.encode("ascii"),
         ),
         params={"param": "test"},
         headers={"X-Test": "test"},
         cookies={"session": "test"},
         content="test",
     )
-    assert request.url == request_raw_url.url, "request.url should be equal to request_raw_url.url"
+    assert (
+        request.url == request_raw_url.url
+    ), "request.url should be equal to request_raw_url.url"
     response = await driver.request(request)
     assert response.status_code == 200
     assert response.content

--- a/tests/test_matcher/test_matcher.py
+++ b/tests/test_matcher/test_matcher.py
@@ -276,3 +276,27 @@ async def test_timedelta_expire(app: App):
         assert test_timedelta_matcher in matchers[test_timedelta_matcher.priority]
         await check_and_run_matcher(test_timedelta_matcher, bot, event, {})
         assert test_timedelta_matcher not in matchers[test_timedelta_matcher.priority]
+
+
+@pytest.mark.asyncio
+async def test_matcher_check(app: App):
+    from plugins.matcher.matcher_check import (
+        to_falsy_rule_matcher,
+        to_bad_rule_matcher,
+        to_falsy_perm_matcher,
+        to_bad_perm_matcher
+    )
+    runned = False
+
+    async def handle():
+        nonlocal runned
+        runned = True
+
+    event = make_fake_event(_type="test")()
+    async with app.test_api() as ctx:
+        bot = ctx.create_bot()
+        await check_and_run_matcher(to_falsy_rule_matcher(handle), bot, event, {})
+        await check_and_run_matcher(to_bad_rule_matcher(handle), bot, event, {})
+        await check_and_run_matcher(to_falsy_perm_matcher(handle), bot, event, {})
+        await check_and_run_matcher(to_bad_perm_matcher(handle), bot, event, {})
+        assert not runned, "matcher should not runned"

--- a/tests/test_matcher/test_matcher.py
+++ b/tests/test_matcher/test_matcher.py
@@ -281,11 +281,12 @@ async def test_timedelta_expire(app: App):
 @pytest.mark.asyncio
 async def test_matcher_check(app: App):
     from plugins.matcher.matcher_check import (
-        to_falsy_rule_matcher,
+        to_bad_perm_matcher,
         to_bad_rule_matcher,
         to_falsy_perm_matcher,
-        to_bad_perm_matcher
+        to_falsy_rule_matcher,
     )
+
     runned = False
 
     async def handle():


### PR DESCRIPTION
- 补message.py的测试
- 补model.py的测试
- 补FileTypes的bug(?

httpx驱动器上传失败 #1647 

nb model.py内会把`files={"test":b"test"}`处理成，`("test", (None, b"test", None))`

> httpx

当FileTypes为`bytes`，不是`Tuple[Optional[str], FileContent, Optional[str]]`时，httpx会默认`file_name="upload"`
但传的是 `Tuple[None, FileContent, Optional[str]]` ，httpx会处理成FileField -> `(None, b'test')`
( 这会导致server端收不到文件?
```python
# httpx/_multipart.py
if isinstance(value, tuple):
    if len(value) == 2:
        # neither the 3rd parameter (content_type) nor the 4th (headers) was included
        filename, fileobj = value  # type: ignore
    elif len(value) == 3:
        filename, fileobj, content_type = value  # type: ignore
    else:
        # all 4 parameters included
        filename, fileobj, content_type, headers = value  # type: ignore
else:
    filename = Path(str(getattr(value, "name", "upload"))).name
```

> aiohttp

没看(



test_file
```python
files=[
    ("test1", b"test"),
    ("test2", ("test.txt", b"test")),
    ("test3", ("test.txt", b"test", "text/plain")),
]

response = await driver.request(request)
data = json.loads(response.content)

// httpx {"test2": "test", "test3": "test"}, "报错""file parsing error"
assert data["files"] == {
    "test1": "test",
    "test2": "test",
    "test3": "test",
}, "file parsing error"

// aiohttp ok
```