### PR TITLE
Fix: 设置 file request 默认 filename

### DIFF
--- a/nonebot/internal/driver/model.py
+++ b/nonebot/internal/driver/model.py
@@ -125,7 +125,7 @@ class Request:
             files_ = files.items() if isinstance(files, dict) else files
             for name, file_info in files_:
                 if not isinstance(file_info, tuple):
-                    self.files.append((name, (None, file_info, None)))
+                    self.files.append((name, (name, file_info, None)))
                 elif len(file_info) == 2:
                     self.files.append((name, (file_info[0], file_info[1], None)))
                 else:

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -282,19 +282,6 @@ async def test_http_client(driver: Driver, server_url: URL):
         "POST",
         server_url,
         data={"form": "test"},
-        files={"test": ("test.txt", b"test")},
-    )
-    response = await driver.request(request)
-    assert response.status_code == 200
-    assert response.content
-    data = json.loads(response.content)
-    assert data["method"] == "POST"
-    assert data["form"] == {"form": "test"}
-    assert data["files"] == {"test": "test"}
-
-    request = Request(
-        "POST",
-        server_url,
         files=[
             ("test1", b"test"),
             ("test2", ("test.txt", b"test")),
@@ -305,7 +292,8 @@ async def test_http_client(driver: Driver, server_url: URL):
     assert response.status_code == 200
     assert response.content
     data = json.loads(response.content)
-
+    assert data["method"] == "POST"
+    assert data["form"] == {"form": "test"}
     assert data["files"] == {
         "test1": "test",
         "test2": "test",

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -294,6 +294,37 @@ async def test_http_client(driver: Driver, server_url: URL):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "driver",
+    [
+        pytest.param("nonebot.drivers.httpx:Driver", id="httpx"),
+        pytest.param("nonebot.drivers.aiohttp:Driver", id="aiohttp"),
+    ],
+    indirect=True,
+)
+async def test_file(driver: Driver, server_url: URL):
+    driver = cast(ForwardDriver, driver)
+    request = Request(
+        "POST",
+        server_url,
+        data={"form": "test"},
+        files=[
+            ("test1", b"test"),
+            ("test2", ("test.txt", b"test")),
+            ("test3", ("test.txt", b"test", "text/plain")),
+        ],
+    )
+    response = await driver.request(request)
+    data = json.loads(response.content)
+
+    assert data["files"] == {
+        "test1": "test",
+        "test2": "test",
+        "test3": "test",
+    }, "file parsing error"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("driver", "driver_type"),
     [
         pytest.param(

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -233,6 +233,20 @@ async def test_http_client(driver: Driver, server_url: URL):
         content="test",
     )
     response = await driver.request(request)
+    request_raw_url = Request(
+        "POST",
+        (
+            server_url.scheme.encode("ascii"),
+            server_url.host.encode("ascii"),
+            server_url.port,
+            server_url.path.encode("ascii")
+        ),
+        params={"param": "test"},
+        headers={"X-Test": "test"},
+        cookies={"session": "test"},
+        content="test",
+    )
+    assert request.url == request_raw_url.url, "request.url should be equal to request_raw_url.url"
     assert response.status_code == 200
     assert response.content
     data = json.loads(response.content)

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -233,6 +233,7 @@ async def test_http_client(driver: Driver, server_url: URL):
         content="test",
     )
     response = await driver.request(request)
+    assert server_url.host is not None
     request_raw_url = Request(
         "POST",
         (
@@ -316,6 +317,8 @@ async def test_file(driver: Driver, server_url: URL):
         ],
     )
     response = await driver.request(request)
+    assert response.status_code == 200
+    assert response.content
     data = json.loads(response.content)
 
     assert data["files"] == {

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -239,14 +239,16 @@ async def test_http_client(driver: Driver, server_url: URL):
             server_url.scheme.encode("ascii"),
             server_url.host.encode("ascii"),
             server_url.port,
-            server_url.path.encode("ascii")
+            server_url.path.encode("ascii"),
         ),
         params={"param": "test"},
         headers={"X-Test": "test"},
         cookies={"session": "test"},
         content="test",
     )
-    assert request.url == request_raw_url.url, "request.url should be equal to request_raw_url.url"
+    assert (
+        request.url == request_raw_url.url
+    ), "request.url should be equal to request_raw_url.url"
     assert response.status_code == 200
     assert response.content
     data = json.loads(response.content)

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -292,24 +292,9 @@ async def test_http_client(driver: Driver, server_url: URL):
     assert data["form"] == {"form": "test"}
     assert data["files"] == {"test": "test"}
 
-    await asyncio.sleep(1)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "driver",
-    [
-        pytest.param("nonebot.drivers.httpx:Driver", id="httpx"),
-        pytest.param("nonebot.drivers.aiohttp:Driver", id="aiohttp"),
-    ],
-    indirect=True,
-)
-async def test_file(driver: Driver, server_url: URL):
-    driver = cast(ForwardDriver, driver)
     request = Request(
         "POST",
         server_url,
-        data={"form": "test"},
         files=[
             ("test1", b"test"),
             ("test2", ("test.txt", b"test")),
@@ -326,6 +311,8 @@ async def test_file(driver: Driver, server_url: URL):
         "test2": "test",
         "test3": "test",
     }, "file parsing error"
+
+    await asyncio.sleep(1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
~`{name:FileContent} -> (name, (None, FileContent, None))`~
`{name:FileContent} -> (name, (name, FileContent, None))`


httpx驱动器上传失败 #1647 

nb model.py内会把`files={"test":b"test"}`处理成，`("test", (None, b"test", None))`

> httpx

当FileTypes为`bytes`，不是`Tuple[Optional[str], FileContent, Optional[str]]`时，httpx会默认`file_name="upload"`
但传的是 `Tuple[None, FileContent, Optional[str]]` ，httpx会处理成FileField -> `(None, b'test')`
( 这会导致server端收不到文件?
```python
# httpx/_multipart.py
if isinstance(value, tuple):
    if len(value) == 2:
        # neither the 3rd parameter (content_type) nor the 4th (headers) was included
        filename, fileobj = value  # type: ignore
    elif len(value) == 3:
        filename, fileobj, content_type = value  # type: ignore
    else:
        # all 4 parameters included
        filename, fileobj, content_type, headers = value  # type: ignore
else:
    filename = Path(str(getattr(value, "name", "upload"))).name
```

> aiohttp

没看(



test_file
```python
files=[
    ("test1", b"test"),
    ("test2", ("test.txt", b"test")),
    ("test3", ("test.txt", b"test", "text/plain")),
]

response = await driver.request(request)
assert response.status_code == 200
assert response.content
data = json.loads(response.content)

// httpx {"test2": "test", "test3": "test"}, "报错""file parsing error"
assert data["files"] == {
    "test1": "test",
    "test2": "test",
    "test3": "test",
}, "file parsing error"

// aiohttp ok
```