### PR TITLE
Feature: 事件响应器的 `__repr__` 方法添加 rule 信息

### DIFF
--- a/nonebot/internal/matcher/matcher.py
+++ b/nonebot/internal/matcher/matcher.py
@@ -78,11 +78,13 @@ class MatcherMeta(type):
     if TYPE_CHECKING:
         module_name: Optional[str]
         type: str
+        rule: Rule
 
     def __repr__(self) -> str:
         return (
             f"{self.__name__}(type={self.type!r}"
             + (f", module={self.module_name}" if self.module_name else "")
+            + (f", rule={self.rule}" if self.rule else "")
             + ")"
         )
 
@@ -142,6 +144,7 @@ class Matcher(metaclass=MatcherMeta):
         return (
             f"{self.__class__.__name__}(type={self.type!r}"
             + (f", module={self.module_name}" if self.module_name else "")
+            + (f", rule={self.rule}" if self.rule else "")
             + ")"
         )
 


### PR DESCRIPTION
目前  `__repr__` 方法展示的信息区分度不足，同一插件内的多个事件响应器无法区分。

通过添加 rule 信息，能够很好的区分不同事件响应器。