### PR TITLE
📝 Docs: 修复配置文档中  配置未填写问题

### DIFF
--- a/website/versioned_docs/version-2.0.0/appendices/config.mdx
+++ b/website/versioned_docs/version-2.0.0/appendices/config.mdx
@@ -185,7 +185,7 @@ superusers = config.superusers
 from pydantic import BaseModel, validator
 
 class Config(BaseModel):
-    weather_api_key: str
+    weather_api_key: str = "weather"
     weather_command_priority: int = 10
     weather_plugin_enabled: bool = True
 

--- a/website/versioned_docs/version-2.0.0rc4/appendices/config.mdx
+++ b/website/versioned_docs/version-2.0.0rc4/appendices/config.mdx
@@ -185,7 +185,7 @@ superusers = config.superusers
 from pydantic import BaseModel, validator
 
 class Config(BaseModel):
-    weather_api_key: str
+    weather_api_key: str = "weather"
     weather_command_priority: int = 10
     weather_plugin_enabled: bool = True
 

--- a/website/versioned_docs/version-2.0.1/appendices/config.mdx
+++ b/website/versioned_docs/version-2.0.1/appendices/config.mdx
@@ -185,7 +185,7 @@ superusers = config.superusers
 from pydantic import BaseModel, validator
 
 class Config(BaseModel):
-    weather_api_key: str
+    weather_api_key: str = "weather"
     weather_command_priority: int = 10
     weather_plugin_enabled: bool = True
 


### PR DESCRIPTION
原先的文档中weather_api_key配置只给了str作为数据类型没有给定值，会导致weather插件无法正常运行
添加”weather“作为值后插件可正常运行