### PR TITLE
Feature: 优先使用 `Annotated` 的最后一个子依赖

### DIFF
--- a/nonebot/internal/params.py
+++ b/nonebot/internal/params.py
@@ -462,7 +462,7 @@ class ArgParam(Param):
                 Required, key=param.default.key or param.name, type=param.default.type
             )
         elif get_origin(param.annotation) is Annotated:
-            for arg in reversed(get_args(param.annotation)):
+            for arg in reversed(get_args(param.annotation)[1::-1]):
                 if isinstance(arg, ArgInner):
                     return cls(Required, key=arg.key or param.name, type=arg.type)
 

--- a/nonebot/internal/params.py
+++ b/nonebot/internal/params.py
@@ -462,7 +462,7 @@ class ArgParam(Param):
                 Required, key=param.default.key or param.name, type=param.default.type
             )
         elif get_origin(param.annotation) is Annotated:
-            for arg in reversed(get_args(param.annotation)[1::-1]):
+            for arg in get_args(param.annotation)[:0:-1]:
                 if isinstance(arg, ArgInner):
                     return cls(Required, key=arg.key or param.name, type=arg.type)
 

--- a/nonebot/internal/params.py
+++ b/nonebot/internal/params.py
@@ -142,7 +142,7 @@ class DependParam(Param):
         if get_origin(param.annotation) is Annotated:
             type_annotation, *extra_args = get_args(param.annotation)
             depends_inner = next(
-                (x for x in extra_args if isinstance(x, DependsInner)), None
+                (x for x in reversed(extra_args) if isinstance(x, DependsInner)), None
             )
 
         # param default value takes higher priority
@@ -462,7 +462,7 @@ class ArgParam(Param):
                 Required, key=param.default.key or param.name, type=param.default.type
             )
         elif get_origin(param.annotation) is Annotated:
-            for arg in get_args(param.annotation):
+            for arg in reversed(get_args(param.annotation)):
                 if isinstance(arg, ArgInner):
                     return cls(Required, key=arg.key or param.name, type=arg.type)
 

--- a/tests/plugins/param/param_arg.py
+++ b/tests/plugins/param/param_arg.py
@@ -26,3 +26,12 @@ async def annotated_arg_str(key: Annotated[str, ArgStr()]) -> str:
 
 async def annotated_arg_plain_text(key: Annotated[str, ArgPlainText()]) -> str:
     return key
+
+
+# test dependency priority
+async def annotated_prior_arg(key: Annotated[str, ArgStr()] = ArgPlainText()):
+    return key
+
+
+async def annotated_multi_arg(key: Annotated[Annotated[str, ArgStr()], ArgPlainText()]):
+    return key

--- a/tests/plugins/param/param_arg.py
+++ b/tests/plugins/param/param_arg.py
@@ -29,9 +29,11 @@ async def annotated_arg_plain_text(key: Annotated[str, ArgPlainText()]) -> str:
 
 
 # test dependency priority
-async def annotated_prior_arg(key: Annotated[str, ArgStr()] = ArgPlainText()):
+async def annotated_prior_arg(key: Annotated[str, ArgStr("foo")] = ArgPlainText()):
     return key
 
 
-async def annotated_multi_arg(key: Annotated[Annotated[str, ArgStr()], ArgPlainText()]):
+async def annotated_multi_arg(
+    key: Annotated[Annotated[str, ArgStr("foo")], ArgPlainText()]
+):
     return key

--- a/tests/plugins/param/param_depend.py
+++ b/tests/plugins/param/param_depend.py
@@ -79,6 +79,12 @@ async def annotated_prior_depend(
     return x
 
 
+async def annotated_multi_depend(
+    x: Annotated[Annotated[int, Depends(lambda: 2)], Depends(dependency)]
+):
+    return x
+
+
 # test sub dependency type mismatch
 async def sub_type_mismatch(b: FooBot = Depends(sub_bot)):
     return b

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -87,6 +87,7 @@ async def test_depend(app: App):
         annotated_multi_depend, allow_types=[DependParam]
     ) as ctx:
         ctx.should_return(1)
+
     assert runned == [1, 1, 1]
 
     async with app.test_dependent(

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -481,6 +481,8 @@ async def test_arg(app: App):
         annotated_arg,
         arg_plain_text,
         annotated_arg_str,
+        annotated_multi_arg,
+        annotated_prior_arg,
         annotated_arg_plain_text,
     )
 
@@ -511,6 +513,14 @@ async def test_arg(app: App):
     async with app.test_dependent(
         annotated_arg_plain_text, allow_types=[ArgParam]
     ) as ctx:
+        ctx.pass_params(matcher=matcher)
+        ctx.should_return(message.extract_plain_text())
+
+    async with app.test_dependent(annotated_multi_arg, allow_types=[ArgParam]) as ctx:
+        ctx.pass_params(matcher=matcher)
+        ctx.should_return(message.extract_plain_text())
+
+    async with app.test_dependent(annotated_prior_arg, allow_types=[ArgParam]) as ctx:
         ctx.pass_params(matcher=matcher)
         ctx.should_return(message.extract_plain_text())
 

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -51,6 +51,7 @@ async def test_depend(app: App):
         sub_type_mismatch,
         validate_field_fail,
         annotated_class_depend,
+        annotated_multi_depend,
         annotated_prior_depend,
     )
 
@@ -81,7 +82,12 @@ async def test_depend(app: App):
         annotated_prior_depend, allow_types=[DependParam]
     ) as ctx:
         ctx.should_return(1)
-    assert runned == [1, 1]
+
+    async with app.test_dependent(
+        annotated_multi_depend, allow_types=[DependParam]
+    ) as ctx:
+        ctx.should_return(1)
+    assert runned == [1, 1, 1]
 
     async with app.test_dependent(
         annotated_class_depend, allow_types=[DependParam]


### PR DESCRIPTION
当前的 `Annotated` 子依赖支持优先使用 metadata 中的**第一个**子依赖。

此 PR 将行为更改成优先使用 metadata 中的**最后一个**子依赖。
借助嵌套 `Annotated` 会被展平，metadata 顺序由最内层向外的特性（`assert Annotated[Annotated[int, ValueRange(3, 10)], ctype("char")] == Annotated[int, ValueRange(3, 10), ctype("char")]`），可以实现 `Annotated` 子依赖的复用：

假设上游提供一个 `User` 子依赖 

```python
User = Annotated[_User, _get_user]

# Usage:
@handler.handle()
async def _(user: User):
    ...
```

在下游，可以重写 `User` 的依赖注入逻辑，而复用 `User` 的类型标注：

```python
CustomUser = Annotated[User, _custom_get_user()]

# Usage:
@handler.handle()
async def _(user: CustomUser):
    ...
```

参见：

- #1832
- https://docs.python.org/3/library/typing.html#typing.Annotated