### PR TITLE
Feature: 添加多消息段命令解析支持

### DIFF
--- a/nonebot/rule.py
+++ b/nonebot/rule.py
@@ -117,27 +117,22 @@ class TrieRule:
                 # check whitespace
                 arg_str = segment_text[len(pf.key) :]
                 arg_str_stripped = arg_str.lstrip()
-                check_remaining_segments = (
-                    len(arg_str_stripped) == 0 and msg and msg[0].is_text()
-                )
-                if check_remaining_segments:
-                    # the arg is from the remaining segments
-                    arg_str = str(msg[0])
+                # check next segment until arg detected or no text remain
+                while not arg_str_stripped and msg and msg[0].is_text():
+                    arg_str += str(msg.pop(0))
                     arg_str_stripped = arg_str.lstrip()
-
-                if (arg_str_stripped or msg) and (
-                    stripped_len := len(arg_str) - len(arg_str_stripped)
-                ) > 0:
+                has_arg = arg_str_stripped or msg
+                if (
+                    has_arg
+                    and (stripped_len := len(arg_str) - len(arg_str_stripped)) > 0
+                ):
                     prefix[CMD_WHITESPACE_KEY] = arg_str[:stripped_len]
 
                 # construct command arg
                 if arg_str_stripped:
-                    if check_remaining_segments:
-                        msg[0] = msg.__class__(arg_str_stripped)[0]
-                    else:
-                        new_message = msg.__class__(arg_str_stripped)
-                        for new_segment in reversed(new_message):
-                            msg.insert(0, new_segment)
+                    new_message = msg.__class__(arg_str_stripped)
+                    for new_segment in reversed(new_message):
+                        msg.insert(0, new_segment)
                 prefix[CMD_ARG_KEY] = msg
 
         return prefix

--- a/nonebot/rule.py
+++ b/nonebot/rule.py
@@ -121,6 +121,7 @@ class TrieRule:
                 while not arg_str_stripped and msg and msg[0].is_text():
                     arg_str += str(msg.pop(0))
                     arg_str_stripped = arg_str.lstrip()
+
                 has_arg = arg_str_stripped or msg
                 if (
                     has_arg

--- a/nonebot/rule.py
+++ b/nonebot/rule.py
@@ -125,10 +125,9 @@ class TrieRule:
                     arg_str = str(msg[0])
                     arg_str_stripped = arg_str.lstrip()
 
-                if (
-                    arg_str_stripped
-                    and (stripped_len := len(arg_str) - len(arg_str_stripped)) > 0
-                ):
+                if (arg_str_stripped or msg) and (
+                    stripped_len := len(arg_str) - len(arg_str_stripped)
+                ) > 0:
                     prefix[CMD_WHITESPACE_KEY] = arg_str[:stripped_len]
 
                 # construct command arg

--- a/nonebot/rule.py
+++ b/nonebot/rule.py
@@ -117,18 +117,28 @@ class TrieRule:
                 # check whitespace
                 arg_str = segment_text[len(pf.key) :]
                 arg_str_stripped = arg_str.lstrip()
-                has_arg = arg_str_stripped or msg
+                check_remaining_segments = (
+                    len(arg_str_stripped) == 0 and msg and msg[0].is_text()
+                )
+                if check_remaining_segments:
+                    # the arg is from the remaining segments
+                    arg_str = str(msg[0])
+                    arg_str_stripped = arg_str.lstrip()
+
                 if (
-                    has_arg
+                    arg_str_stripped
                     and (stripped_len := len(arg_str) - len(arg_str_stripped)) > 0
                 ):
                     prefix[CMD_WHITESPACE_KEY] = arg_str[:stripped_len]
 
                 # construct command arg
                 if arg_str_stripped:
-                    new_message = msg.__class__(arg_str_stripped)
-                    for new_segment in reversed(new_message):
-                        msg.insert(0, new_segment)
+                    if check_remaining_segments:
+                        msg[0] = msg.__class__(arg_str_stripped)[0]
+                    else:
+                        new_message = msg.__class__(arg_str_stripped)
+                        for new_segment in reversed(new_message):
+                            msg.insert(0, new_segment)
                 prefix[CMD_ARG_KEY] = msg
 
         return prefix

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -113,6 +113,20 @@ async def test_trie(app: App):
             command_whitespace=" ",
         )
 
+        message = FakeMessageSegment.text("/fake-prefix") + FakeMessageSegment.text(
+            " some args"
+        )
+        event = make_fake_event(_message=message)()
+        state = {}
+        TrieRule.get_value(bot, event, state)
+        assert state[PREFIX_KEY] == CMD_RESULT(
+            command=("fake-prefix",),
+            raw_command="/fake-prefix",
+            command_arg=FakeMessage("some args"),
+            command_start="/",
+            command_whitespace=" ",
+        )
+
     del TrieRule.prefix["/fake-prefix"]
 
 

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -113,7 +113,7 @@ async def test_trie(app: App):
             command_whitespace=" ",
         )
 
-        message = FakeMessageSegment.text("/fake-prefix") + FakeMessageSegment.text(
+        message = FakeMessageSegment.text("/fake-prefix ") + FakeMessageSegment.text(
             " some args"
         )
         event = make_fake_event(_message=message)()
@@ -124,7 +124,23 @@ async def test_trie(app: App):
             raw_command="/fake-prefix",
             command_arg=FakeMessage("some args"),
             command_start="/",
-            command_whitespace=" ",
+            command_whitespace="  ",
+        )
+
+        message = (
+            FakeMessageSegment.text("/fake-prefix ")
+            + FakeMessageSegment.text("    ")
+            + FakeMessageSegment.text(" some args")
+        )
+        event = make_fake_event(_message=message)()
+        state = {}
+        TrieRule.get_value(bot, event, state)
+        assert state[PREFIX_KEY] == CMD_RESULT(
+            command=("fake-prefix",),
+            raw_command="/fake-prefix",
+            command_arg=FakeMessage("some args"),
+            command_start="/",
+            command_whitespace="      ",
         )
 
     del TrieRule.prefix["/fake-prefix"]


### PR DESCRIPTION
### 背景
采用 [nonebot/adapter-telegram](https://github.com/nonebot/adapter-telegram) 作为 Telegram 的 adapter 时，带有命令的消息是分段的。例如 `"/weather Beijing"` 将会被分为 `["/weather", " Beijing"]` (注意第二段包含空白符)。

### 现有 bug
现有的命令 parsing 的结果是
- `prefix[CMD_ARG_KEY] = " Beijing"` (包含了空白符)
- `prefix[CMD_WHITESPACE_KEY] = None` (无法识别空白符)

在这种场景下，`on_command` 的 `force_whitespace` 参数也会失效。

### 修复
增加对于分段消息的处理。修复后的 parsing 结果是
- `prefix[CMD_ARG_KEY] = "Beijing"` (删除了左侧空白符)
- `prefix[CMD_WHITESPACE_KEY] = " "`
