### PR TITLE
Feature: 带参数的 `RegexStr()`

### DIFF
--- a/nonebot/params.py
+++ b/nonebot/params.py
@@ -5,7 +5,18 @@ FrontMatter:
     description: nonebot.params 模块
 """
 
-from typing import Any, Dict, List, Match, Tuple, Union, Optional
+from typing import (
+    Any,
+    Dict,
+    List,
+    Match,
+    Tuple,
+    Union,
+    Literal,
+    Callable,
+    Optional,
+    overload,
+)
 
 from nonebot.typing import T_State
 from nonebot.matcher import Matcher
@@ -147,13 +158,37 @@ def RegexMatched() -> Match[str]:
     return Depends(_regex_matched, use_cache=False)
 
 
-def _regex_str(state: T_State) -> str:
-    return _regex_matched(state).group()
+def _regex_str(
+    groups: Tuple[Union[str, int], ...]
+) -> Callable[[T_State], Union[str, Tuple[Union[str, Any], ...], Any]]:
+    def _regex_str_dependency(
+        state: T_State,
+    ) -> Union[str, Tuple[Union[str, Any], ...], Any]:
+        return _regex_matched(state).group(*groups)
+
+    return _regex_str_dependency
 
 
-def RegexStr() -> str:
+@overload
+def RegexStr(__group: Literal[0] = 0) -> str:
+    ...
+
+
+@overload
+def RegexStr(__group: Union[str, int]) -> Union[str, Any]:
+    ...
+
+
+@overload
+def RegexStr(
+    __group1: Union[str, int], __group2: Union[str, int], *groups: Union[str, int]
+) -> Tuple[Union[str, Any], ...]:
+    ...
+
+
+def RegexStr(*groups: Union[str, int]) -> Union[str, Tuple[Union[str, Any], ...], Any]:
     """正则匹配结果文本"""
-    return Depends(_regex_str, use_cache=False)
+    return Depends(_regex_str(groups), use_cache=False)
 
 
 def _regex_group(state: T_State) -> Tuple[Any, ...]:

--- a/tests/plugins/param/param_state.py
+++ b/tests/plugins/param/param_state.py
@@ -77,8 +77,13 @@ async def regex_matched(regex_matched: Match[str] = RegexMatched()) -> Match[str
     return regex_matched
 
 
-async def regex_str(regex_str: str = RegexStr()) -> str:
-    return regex_str
+async def regex_str(
+    entire: str = RegexStr(),
+    type_: str = RegexStr("type"),
+    second: str = RegexStr(2),
+    groups: Tuple[str, ...] = RegexStr(1, "arg"),
+) -> Tuple[str, str, str, Tuple[str, ...]]:
+    return entire, type_, second, groups
 
 
 async def startswith(startswith: str = Startswith()) -> str:

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -361,7 +361,9 @@ async def test_state(app: App):
         regex_str, allow_types=[StateParam, DependParam]
     ) as ctx:
         ctx.pass_params(state=fake_state)
-        ctx.should_return("[cq:test,arg=value]")
+        ctx.should_return(
+            ("[cq:test,arg=value]", "test", "arg=value", ("test", "arg=value"))
+        )
 
     async with app.test_dependent(
         regex_group, allow_types=[StateParam, DependParam]


### PR DESCRIPTION
[Match.group()](https://docs.python.org/zh-cn/3/library/re.html#re.Match.group) 无参数时返回整个正则表达式匹配的字符串, 也可以通过传入参数获得特定的捕获组.
而 `RegexStr()` 现在只支持无参数调用, 不支持传入参数.

此 pull request 实现了向 `RegexStr()` 传入参数以获得特定捕获组的功能.
例：
```python
matcher = on_regex(r"\[cq:(?P<type>.*?),(?P<arg>.*?)\]")


@matcher.handle()
async def _(type_: str = RegexStr(1), arg: str = RegexStr("arg")):
    ...
```