### PR TITLE
Fix: `MessageTemplate` 禁止访问私有属性

### DIFF
--- a/nonebot/internal/adapter/template.py
+++ b/nonebot/internal/adapter/template.py
@@ -194,7 +194,7 @@ class MessageTemplate(Formatter, Generic[TF]):
 
         for is_attr, value in rest:
             if not self.private_getattr and value.startswith("_"):
-                raise ValueError("attribute name must not start with underscore")
+                raise ValueError("Cannot access private attribute")
             obj = getattr(obj, value) if is_attr else obj[value]
 
         return obj, first

--- a/nonebot/internal/adapter/template.py
+++ b/nonebot/internal/adapter/template.py
@@ -1,7 +1,5 @@
 import functools
 from string import Formatter
-from _string import formatter_field_name_split  # type: ignore
-
 from typing_extensions import TypeAlias
 from typing import (
     TYPE_CHECKING,
@@ -21,6 +19,8 @@ from typing import (
     cast,
     overload,
 )
+
+from _string import formatter_field_name_split  # type: ignore
 
 if TYPE_CHECKING:
     from .message import Message, MessageSegment

--- a/nonebot/internal/adapter/template.py
+++ b/nonebot/internal/adapter/template.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
         field_name: str,
     ) -> Tuple[str, List[Tuple[bool, str]]]:
         ...
+
 else:
     from _string import formatter_field_name_split
 

--- a/nonebot/internal/adapter/template.py
+++ b/nonebot/internal/adapter/template.py
@@ -44,17 +44,24 @@ class MessageTemplate(Formatter, Generic[TF]):
     参数:
         template: 模板
         factory: 消息类型工厂，默认为 `str`
+        private_getattr: 是否允许在模板中访问私有属性，默认为 `False`
     """
 
     @overload
     def __init__(
-        self: "MessageTemplate[str]", template: str, factory: Type[str] = str
+        self: "MessageTemplate[str]",
+        template: str,
+        factory: Type[str] = str,
+        private_getattr: bool = False,
     ) -> None:
         ...
 
     @overload
     def __init__(
-        self: "MessageTemplate[TM]", template: Union[str, TM], factory: Type[TM]
+        self: "MessageTemplate[TM]",
+        template: Union[str, TM],
+        factory: Type[TM],
+        private_getattr: bool = False,
     ) -> None:
         ...
 
@@ -62,11 +69,12 @@ class MessageTemplate(Formatter, Generic[TF]):
         self,
         template: Union[str, TM],
         factory: Union[Type[str], Type[TM]] = str,
+        private_getattr: bool = False,
     ) -> None:
         self.template: TF = template  # type: ignore
         self.factory: Type[TF] = factory  # type: ignore
         self.format_specs: Dict[str, FormatSpecFunc] = {}
-        self.private_getattr = False
+        self.private_getattr = private_getattr
 
     def __repr__(self) -> str:
         return f"MessageTemplate({self.template!r}, factory={self.factory!r})"

--- a/nonebot/internal/adapter/template.py
+++ b/nonebot/internal/adapter/template.py
@@ -1,5 +1,7 @@
 import functools
 from string import Formatter
+from _string import formatter_field_name_split  # type: ignore
+
 from typing_extensions import TypeAlias
 from typing import (
     TYPE_CHECKING,
@@ -23,13 +25,11 @@ from typing import (
 if TYPE_CHECKING:
     from .message import Message, MessageSegment
 
-    def formatter_field_name_split(
+    def formatter_field_name_split(  # noqa: F811
         field_name: str,
     ) -> Tuple[str, List[Tuple[bool, str]]]:
         ...
 
-else:
-    from _string import formatter_field_name_split
 
 TM = TypeVar("TM", bound="Message")
 TF = TypeVar("TF", str, "Message")
@@ -188,7 +188,7 @@ class MessageTemplate(Formatter, Generic[TF]):
 
     def get_field(
         self, field_name: str, args: Sequence[Any], kwargs: Mapping[str, Any]
-    ) -> Any:
+    ) -> Tuple[Any, Union[int, str]]:
         first, rest = formatter_field_name_split(field_name)
         obj = self.get_value(first, args, kwargs)
 

--- a/nonebot/internal/adapter/template.py
+++ b/nonebot/internal/adapter/template.py
@@ -185,7 +185,7 @@ class MessageTemplate(Formatter, Generic[TF]):
         obj = self.get_value(first, args, kwargs)
 
         for is_attr, value in rest:
-            if not self.private_getattr and is_attr and value.startswith("_"):
+            if not self.private_getattr and value.startswith("_"):
                 raise ValueError("attribute name must not start with underscore")
             obj = getattr(obj, value) if is_attr else obj[value]
 

--- a/tests/test_adapters/test_template.py
+++ b/tests/test_adapters/test_template.py
@@ -1,6 +1,7 @@
+import pytest
+
 from nonebot.adapters import MessageTemplate
 from utils import FakeMessage, FakeMessageSegment, escape_text
-import pytest
 
 
 def test_template_basis():

--- a/tests/test_adapters/test_template.py
+++ b/tests/test_adapters/test_template.py
@@ -62,12 +62,13 @@ def test_malformed_template():
     message = positive_template.format(a="a", b="b")
     assert message.extract_plain_text() == "ab"
 
-    malformed_template = FakeMessage.template(
-        "{a.__init__}{b[__builtins__][__import__]}"
-    )
-
+    malformed_template = FakeMessage.template("{a.__init__}")
     with pytest.raises(ValueError, match="must not start with"):
-        message = malformed_template.format(a="a", b=globals())
+        message = malformed_template.format(a="a")
+
+    malformed_template = FakeMessage.template("{a[__builtins__]}")
+    with pytest.raises(ValueError, match="must not start with"):
+        message = malformed_template.format(a=globals())
 
     malformed_template.private_getattr = True
-    message = malformed_template.format(a="a", b=globals())
+    message = malformed_template.format(a=globals())

--- a/tests/test_adapters/test_template.py
+++ b/tests/test_adapters/test_template.py
@@ -70,5 +70,7 @@ def test_malformed_template():
     with pytest.raises(ValueError, match="must not start with"):
         message = malformed_template.format(a=globals())
 
-    malformed_template.private_getattr = True
-    message = malformed_template.format(a=globals())
+    malformed_template = MessageTemplate(
+        "{a[__builtins__][__import__]}{b.__init__}", private_getattr=True
+    )
+    message = malformed_template.format(a=globals(), b="b")

--- a/tests/test_adapters/test_template.py
+++ b/tests/test_adapters/test_template.py
@@ -63,11 +63,11 @@ def test_malformed_template():
     assert message.extract_plain_text() == "ab"
 
     malformed_template = FakeMessage.template("{a.__init__}")
-    with pytest.raises(ValueError, match="must not start with"):
+    with pytest.raises(ValueError, match="private attribute"):
         message = malformed_template.format(a="a")
 
     malformed_template = FakeMessage.template("{a[__builtins__]}")
-    with pytest.raises(ValueError, match="must not start with"):
+    with pytest.raises(ValueError, match="private attribute"):
         message = malformed_template.format(a=globals())
 
     malformed_template = MessageTemplate(


### PR DESCRIPTION
To prevent potential information leak caused by format string injection.