### PR TITLE
重名插件支持

### DIFF
--- a/nonebot/__init__.py
+++ b/nonebot/__init__.py
@@ -355,8 +355,10 @@ from nonebot.plugin import on_shell_command as on_shell_command
 from nonebot.plugin import get_loaded_plugins as get_loaded_plugins
 from nonebot.plugin import load_builtin_plugin as load_builtin_plugin
 from nonebot.plugin import load_builtin_plugins as load_builtin_plugins
-from nonebot.plugin import get_available_plugin_ids as get_available_plugin_ids
 from nonebot.plugin import get_plugin_by_module_name as get_plugin_by_module_name
 from nonebot.plugin import get_available_plugin_names as get_available_plugin_names
+from nonebot.plugin import (
+    get_available_plugin_fullpaths as get_available_plugin_fullpaths,
+)
 
 __autodoc__ = {"internal": False}

--- a/nonebot/__init__.py
+++ b/nonebot/__init__.py
@@ -355,6 +355,7 @@ from nonebot.plugin import on_shell_command as on_shell_command
 from nonebot.plugin import get_loaded_plugins as get_loaded_plugins
 from nonebot.plugin import load_builtin_plugin as load_builtin_plugin
 from nonebot.plugin import load_builtin_plugins as load_builtin_plugins
+from nonebot.plugin import get_available_plugin_ids as get_available_plugin_ids
 from nonebot.plugin import get_plugin_by_module_name as get_plugin_by_module_name
 from nonebot.plugin import get_available_plugin_names as get_available_plugin_names
 

--- a/nonebot/plugin/__init__.py
+++ b/nonebot/plugin/__init__.py
@@ -60,7 +60,7 @@ def _plugin_name_to_plugin_fullpath(
         return (*(parent.name for parent in parents), plugin_name)
     for pre_plugin in reversed(parents):
         if _managers.index(pre_plugin.manager) < _managers.index(manager):
-            return (*pre_plugin.fullpath, plugin_name)
+            return (*pre_plugin.plugin_fullpath, plugin_name)
     else:
         return (plugin_name,)
 
@@ -82,7 +82,7 @@ def _revert_plugin(plugin: "Plugin") -> None:
     if plugin.name not in _plugins:
         raise RuntimeError("Plugin not found!")
     del _plugins[plugin.name]
-    del _plugins[plugin.fullpath]
+    del _plugins[plugin.plugin_fullpath]
     if parent_plugin := plugin.parent_plugin:
         parent_plugin.sub_plugins.remove(plugin)
 
@@ -93,7 +93,8 @@ def get_plugin(name: Union[str, Tuple[str, ...]]) -> Optional["Plugin"]:
     如果为 `load_plugins` 文件夹导入的插件，则为文件(夹)名。
 
     参数:
-        name: 插件名，即 {ref}`nonebot.plugin.model.Plugin.name`。
+        name: 插件名或插件路径，即 {ref}`nonebot.plugin.model.Plugin.name`
+            或 {ref}`nonebot.plugin.model.Plugin.plugin_fullpath`。
     """
     return _plugins.get(name)
 
@@ -131,7 +132,7 @@ def get_available_plugin_names() -> Set[str]:
 
 
 def get_available_plugin_fullpaths() -> Set[Tuple[str, ...]]:
-    """获取当前所有可用的插件名（包含尚未加载的插件）。"""
+    """获取当前所有可用的插件模块路径（包含尚未加载的插件）。"""
     return {
         plugin
         for plugin in chain.from_iterable(

--- a/nonebot/plugin/__init__.py
+++ b/nonebot/plugin/__init__.py
@@ -70,7 +70,7 @@ def _new_plugin(
 ) -> "Plugin":
     plugin_name = _module_name_to_plugin_name(module_name)
     plugin_id = _plugin_name_to_plugin_id(plugin_name, manager)
-    if plugin_name in _plugins or plugin_id in _plugins:
+    if plugin_id in _plugins:
         raise RuntimeError("Plugin already exists! Check your plugin name.")
     plugin = Plugin(plugin_name, module, module_name, manager)
     _plugins[plugin_name] = plugin

--- a/nonebot/plugin/__init__.py
+++ b/nonebot/plugin/__init__.py
@@ -132,7 +132,7 @@ def get_available_plugin_names() -> Set[str]:
 
 
 def get_available_plugin_fullpaths() -> Set[Tuple[str, ...]]:
-    """获取当前所有可用的插件模块路径（包含尚未加载的插件）。"""
+    """获取当前所有可用的插件路径（包含尚未加载的插件）。"""
     return {
         plugin
         for plugin in chain.from_iterable(

--- a/nonebot/plugin/__init__.py
+++ b/nonebot/plugin/__init__.py
@@ -60,7 +60,7 @@ def _plugin_name_to_plugin_fullpath(
         return (*(parent.name for parent in parents), plugin_name)
     for pre_plugin in reversed(parents):
         if _managers.index(pre_plugin.manager) < _managers.index(manager):
-            return (*pre_plugin.fillpath, plugin_name)
+            return (*pre_plugin.fullpath, plugin_name)
     else:
         return (plugin_name,)
 
@@ -82,7 +82,7 @@ def _revert_plugin(plugin: "Plugin") -> None:
     if plugin.name not in _plugins:
         raise RuntimeError("Plugin not found!")
     del _plugins[plugin.name]
-    del _plugins[plugin.fillpath]
+    del _plugins[plugin.fullpath]
     if parent_plugin := plugin.parent_plugin:
         parent_plugin.sub_plugins.remove(plugin)
 

--- a/nonebot/plugin/load.py
+++ b/nonebot/plugin/load.py
@@ -14,13 +14,7 @@ from nonebot.utils import path_to_module_name
 
 from .model import Plugin
 from .manager import PluginManager
-from . import (
-    _managers,
-    get_plugin,
-    _current_plugin_chain,
-    _plugin_name_to_plugin_id,
-    _module_name_to_plugin_name,
-)
+from . import _managers, get_plugin, _current_plugin_chain, _module_name_to_plugin_name
 
 try:  # pragma: py-gte-311
     import tomllib  # pyright: ignore[reportMissingImports]

--- a/nonebot/plugin/load.py
+++ b/nonebot/plugin/load.py
@@ -160,7 +160,8 @@ def require(name: Union[str, Tuple[str, ...]]) -> ModuleType:
     如果为 `load_plugins` 文件夹导入的插件，则为文件(夹)名。
 
     参数:
-        name: 插件名，即 {ref}`nonebot.plugin.model.Plugin.name`。
+        name: 插件名或插件路径，即 {ref}`nonebot.plugin.model.Plugin.name`
+            或 {ref}`nonebot.plugin.model.Plugin.plugin_fullpath`。
 
     异常:
         RuntimeError: 插件无法加载

--- a/nonebot/plugin/manager.py
+++ b/nonebot/plugin/manager.py
@@ -112,7 +112,6 @@ class PluginManager:
                 continue
 
             plugin_fullpath = _plugin_name_to_plugin_fullpath(module_info.name)
-            plugin_fullpath_str = ".".join(plugin_fullpath)
 
             if (
                 plugin_fullpath in searched_plugins
@@ -120,7 +119,7 @@ class PluginManager:
                 or plugin_fullpath in third_party_plugins
             ):
                 raise RuntimeError(
-                    f"Plugin already exists: {plugin_fullpath_str}! Check your plugin name"
+                    f"Plugin already exists: {plugin_fullpath}! Check your plugin name"
                 )
 
             if not (
@@ -144,7 +143,7 @@ class PluginManager:
         对于独立插件，可以使用完整插件模块名或者插件名称。
 
         参数:
-            name: 插件名称。
+            name: 插件名称或插件路径。
         """
 
         try:

--- a/nonebot/plugin/manager.py
+++ b/nonebot/plugin/manager.py
@@ -93,13 +93,12 @@ class PluginManager:
         for plugin in self.plugins:
             name = _module_name_to_plugin_name(plugin)
             plugin_fullpath = _plugin_name_to_plugin_fullpath(name)
-            plugin_fullpath_str = ".".join(plugin_fullpath)
             if (
                 plugin_fullpath in third_party_plugins
                 or plugin_fullpath in previous_plugins
             ):
                 raise RuntimeError(
-                    f"Plugin already exists: {plugin_fullpath_str}! Check your plugin name"
+                    f"Plugin already exists: {plugin_fullpath}! Check your plugin name"
                 )
             third_party_plugins[name] = plugin
             third_party_plugins[plugin_fullpath] = plugin

--- a/nonebot/plugin/manager.py
+++ b/nonebot/plugin/manager.py
@@ -26,8 +26,8 @@ from . import (
     _new_plugin,
     _revert_plugin,
     _current_plugin_chain,
-    _plugin_name_to_plugin_id,
     _module_name_to_plugin_name,
+    _plugin_name_to_plugin_fullpath,
 )
 
 
@@ -92,14 +92,17 @@ class PluginManager:
         # check third party plugins
         for plugin in self.plugins:
             name = _module_name_to_plugin_name(plugin)
-            plugin_id = _plugin_name_to_plugin_id(name)
-            plugin_id_str = ".".join(plugin_id)
-            if plugin_id in third_party_plugins or plugin_id in previous_plugins:
+            plugin_fullpath = _plugin_name_to_plugin_fullpath(name)
+            plugin_fullpath_str = ".".join(plugin_fullpath)
+            if (
+                plugin_fullpath in third_party_plugins
+                or plugin_fullpath in previous_plugins
+            ):
                 raise RuntimeError(
-                    f"Plugin already exists: {plugin_id_str}! Check your plugin name"
+                    f"Plugin already exists: {plugin_fullpath_str}! Check your plugin name"
                 )
             third_party_plugins[name] = plugin
-            third_party_plugins[plugin_id] = plugin
+            third_party_plugins[plugin_fullpath] = plugin
 
         self._third_party_plugin_names = third_party_plugins
 
@@ -109,16 +112,16 @@ class PluginManager:
             if module_info.name.startswith("_"):
                 continue
 
-            plugin_id = _plugin_name_to_plugin_id(module_info.name)
-            plugin_id_str = ".".join(plugin_id)
+            plugin_fullpath = _plugin_name_to_plugin_fullpath(module_info.name)
+            plugin_fullpath_str = ".".join(plugin_fullpath)
 
             if (
-                plugin_id in searched_plugins
-                or plugin_id in previous_plugins
-                or plugin_id in third_party_plugins
+                plugin_fullpath in searched_plugins
+                or plugin_fullpath in previous_plugins
+                or plugin_fullpath in third_party_plugins
             ):
                 raise RuntimeError(
-                    f"Plugin already exists: {plugin_id_str}! Check your plugin name"
+                    f"Plugin already exists: {plugin_fullpath_str}! Check your plugin name"
                 )
 
             if not (
@@ -130,7 +133,7 @@ class PluginManager:
             if not (module_path := module_spec.origin):
                 continue
             searched_plugins[module_info.name] = Path(module_path).resolve()
-            searched_plugins[plugin_id] = Path(module_path).resolve()
+            searched_plugins[plugin_fullpath] = Path(module_path).resolve()
 
         self._searched_plugin_names = searched_plugins
 

--- a/nonebot/plugin/model.py
+++ b/nonebot/plugin/model.py
@@ -82,8 +82,9 @@ class Plugin:
     metadata: Optional[PluginMetadata] = None
 
     @property
-    def fullpath(self) -> Tuple[str, ...]:
+    def plugin_fullpath(self) -> Tuple[str, ...]:
+        """插件路径，返回一个插件从顶层插件到底层的所有插件名元组"""
         if self.parent_plugin is None:
             return (self.name,)
         else:
-            return (*self.parent_plugin.fullpath, self.name)
+            return (*self.parent_plugin.plugin_fullpath, self.name)

--- a/nonebot/plugin/model.py
+++ b/nonebot/plugin/model.py
@@ -8,7 +8,7 @@ FrontMatter:
 import contextlib
 from types import ModuleType
 from dataclasses import field, dataclass
-from typing import TYPE_CHECKING, Any, Set, Dict, Type, Optional
+from typing import TYPE_CHECKING, Any, Set, Dict, Type, Tuple, Optional
 
 from pydantic import BaseModel
 
@@ -80,3 +80,10 @@ class Plugin:
     sub_plugins: Set["Plugin"] = field(default_factory=set)
     """子插件集合"""
     metadata: Optional[PluginMetadata] = None
+
+    @property
+    def id(self) -> Tuple[str, ...]:
+        if self.parent_plugin is None:
+            return (self.name,)
+        else:
+            return (*self.parent_plugin.id, self.name)

--- a/nonebot/plugin/model.py
+++ b/nonebot/plugin/model.py
@@ -82,8 +82,8 @@ class Plugin:
     metadata: Optional[PluginMetadata] = None
 
     @property
-    def fillpath(self) -> Tuple[str, ...]:
+    def fullpath(self) -> Tuple[str, ...]:
         if self.parent_plugin is None:
             return (self.name,)
         else:
-            return (*self.parent_plugin.fillpath, self.name)
+            return (*self.parent_plugin.fullpath, self.name)

--- a/nonebot/plugin/model.py
+++ b/nonebot/plugin/model.py
@@ -82,8 +82,8 @@ class Plugin:
     metadata: Optional[PluginMetadata] = None
 
     @property
-    def id(self) -> Tuple[str, ...]:
+    def fillpath(self) -> Tuple[str, ...]:
         if self.parent_plugin is None:
             return (self.name,)
         else:
-            return (*self.parent_plugin.id, self.name)
+            return (*self.parent_plugin.fillpath, self.name)

--- a/tests/plugins/multinested/__init__.py
+++ b/tests/plugins/multinested/__init__.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+import nonebot
+
+sub_plugins = nonebot.load_plugins(
+    str(Path(__file__).parent.joinpath("plugins").resolve())
+)

--- a/tests/plugins/multinested/plugins/multinested_samename_subplugin/__init__.py
+++ b/tests/plugins/multinested/plugins/multinested_samename_subplugin/__init__.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+import nonebot
+
+sub_plugins = nonebot.load_plugins(
+    str(Path(__file__).parent.joinpath("plugins").resolve())
+)

--- a/tests/plugins/multinested/plugins/multinested_samename_subplugin/plugins/multinested_samename_anotherplugin.py
+++ b/tests/plugins/multinested/plugins/multinested_samename_subplugin/plugins/multinested_samename_anotherplugin.py
@@ -1,0 +1,1 @@
+a = "subsame.another"

--- a/tests/plugins/multinested/plugins/multinested_samename_subplugin/plugins/multinested_samename_subplugin.py
+++ b/tests/plugins/multinested/plugins/multinested_samename_subplugin/plugins/multinested_samename_subplugin.py
@@ -1,0 +1,1 @@
+a = "subsame.subsame"

--- a/tests/plugins/multinested/plugins/multinested_subnested1/__init__.py
+++ b/tests/plugins/multinested/plugins/multinested_subnested1/__init__.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+import nonebot
+
+sub_plugins = nonebot.load_plugins(
+    str(Path(__file__).parent.joinpath("plugins").resolve())
+)

--- a/tests/plugins/multinested/plugins/multinested_subnested1/plugins/multinested_samename_subplugin.py
+++ b/tests/plugins/multinested/plugins/multinested_subnested1/plugins/multinested_samename_subplugin.py
@@ -1,0 +1,1 @@
+a = "sub1.subsame"

--- a/tests/plugins/multinested/plugins/multinested_subnested1/plugins/multinested_subnested1_plugin.py
+++ b/tests/plugins/multinested/plugins/multinested_subnested1/plugins/multinested_subnested1_plugin.py
@@ -1,0 +1,1 @@
+a = "sub1.another"

--- a/tests/plugins/multinested/plugins/multinested_subnested2/__init__.py
+++ b/tests/plugins/multinested/plugins/multinested_subnested2/__init__.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+import nonebot
+
+sub_plugins = nonebot.load_plugins(
+    str(Path(__file__).parent.joinpath("plugins").resolve())
+)

--- a/tests/plugins/multinested/plugins/multinested_subnested2/plugins/multinested_samename_subplugin.py
+++ b/tests/plugins/multinested/plugins/multinested_subnested2/plugins/multinested_samename_subplugin.py
@@ -1,0 +1,1 @@
+a = "sub2.subsame"

--- a/tests/plugins/multinested/plugins/multinested_subnested2/plugins/multinested_subnested2_plugin.py
+++ b/tests/plugins/multinested/plugins/multinested_subnested2/plugins/multinested_subnested2_plugin.py
@@ -1,0 +1,1 @@
+a = "sub2.another"

--- a/tests/test_plugin/test_get.py
+++ b/tests/test_plugin/test_get.py
@@ -54,8 +54,8 @@ async def test_get_available_plugin():
         plugin_names = nonebot.get_available_plugin_names()
         assert plugin_names == {"export", "require"}
         # check get available plugins' id
-        plugin_ids = nonebot.get_available_plugin_ids()
-        assert plugin_ids == {("export",), ("require",)}
+        plugin_fullpaths = nonebot.get_available_plugin_fullpaths()
+        assert plugin_fullpaths == {("export",), ("require",)}
     finally:
         _managers.clear()
         _managers.extend(old_managers)

--- a/tests/test_plugin/test_get.py
+++ b/tests/test_plugin/test_get.py
@@ -28,19 +28,23 @@ async def test_get_plugin_by_id():
     plugin = nonebot.get_plugin(("export",))
     assert plugin
     assert plugin.module_name == "plugins.export"
+    assert plugin.fullpath == ("export",)
 
     # check sub plugin
     plugin = nonebot.get_plugin(("nested",))
     assert plugin
     assert plugin.module_name == "plugins.nested"
+    assert plugin.fullpath == ("nested",)
 
     plugin = nonebot.get_plugin(("nested", "nested_subplugin"))
     assert plugin
     assert plugin.module_name == "plugins.nested.plugins.nested_subplugin"
+    assert plugin.fullpath == ("nested", "nested_subplugin")
 
     plugin = nonebot.get_plugin(("nested", "nested_subplugin2"))
     assert plugin
     assert plugin.module_name == "plugins.nested.plugins.nested_subplugin2"
+    assert plugin.fullpath == ("nested", "nested_subplugin2")
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin/test_get.py
+++ b/tests/test_plugin/test_get.py
@@ -23,6 +23,27 @@ async def test_get_plugin():
 
 
 @pytest.mark.asyncio
+async def test_get_plugin_by_id():
+    # check simple plugin
+    plugin = nonebot.get_plugin(("export",))
+    assert plugin
+    assert plugin.module_name == "plugins.export"
+
+    # check sub plugin
+    plugin = nonebot.get_plugin(("nested",))
+    assert plugin
+    assert plugin.module_name == "plugins.nested"
+
+    plugin = nonebot.get_plugin(("nested", "nested_subplugin"))
+    assert plugin
+    assert plugin.module_name == "plugins.nested.plugins.nested_subplugin"
+
+    plugin = nonebot.get_plugin(("nested", "nested_subplugin2"))
+    assert plugin
+    assert plugin.module_name == "plugins.nested.plugins.nested_subplugin2"
+
+
+@pytest.mark.asyncio
 async def test_get_available_plugin():
     old_managers = _managers.copy()
     _managers.clear()
@@ -32,6 +53,9 @@ async def test_get_available_plugin():
         # check get available plugins
         plugin_names = nonebot.get_available_plugin_names()
         assert plugin_names == {"export", "require"}
+        # check get available plugins' id
+        plugin_ids = nonebot.get_available_plugin_ids()
+        assert plugin_ids == {("export",), ("require",)}
     finally:
         _managers.clear()
         _managers.extend(old_managers)

--- a/tests/test_plugin/test_get.py
+++ b/tests/test_plugin/test_get.py
@@ -28,23 +28,23 @@ async def test_get_plugin_by_id():
     plugin = nonebot.get_plugin(("export",))
     assert plugin
     assert plugin.module_name == "plugins.export"
-    assert plugin.fullpath == ("export",)
+    assert plugin.plugin_fullpath == ("export",)
 
     # check sub plugin
     plugin = nonebot.get_plugin(("nested",))
     assert plugin
     assert plugin.module_name == "plugins.nested"
-    assert plugin.fullpath == ("nested",)
+    assert plugin.plugin_fullpath == ("nested",)
 
     plugin = nonebot.get_plugin(("nested", "nested_subplugin"))
     assert plugin
     assert plugin.module_name == "plugins.nested.plugins.nested_subplugin"
-    assert plugin.fullpath == ("nested", "nested_subplugin")
+    assert plugin.plugin_fullpath == ("nested", "nested_subplugin")
 
     plugin = nonebot.get_plugin(("nested", "nested_subplugin2"))
     assert plugin
     assert plugin.module_name == "plugins.nested.plugins.nested_subplugin2"
-    assert plugin.fullpath == ("nested", "nested_subplugin2")
+    assert plugin.plugin_fullpath == ("nested", "nested_subplugin2")
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin/test_get.py
+++ b/tests/test_plugin/test_get.py
@@ -57,7 +57,7 @@ async def test_get_available_plugin():
         # check get available plugins
         plugin_names = nonebot.get_available_plugin_names()
         assert plugin_names == {"export", "require"}
-        # check get available plugins' id
+        # check get available plugins' fullpath
         plugin_fullpaths = nonebot.get_available_plugin_fullpaths()
         assert plugin_fullpaths == {("export",), ("require",)}
     finally:

--- a/tests/test_plugin/test_load.py
+++ b/tests/test_plugin/test_load.py
@@ -250,7 +250,7 @@ async def test_require_not_found():
         nonebot.require("some_plugin_not_exist")
 
     with pytest.raises(RuntimeError):
-        nonebot.require(("some_plugin_id_not_exist",))
+        nonebot.require(("some_plugin_fullpath_not_exist",))
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin/test_load.py
+++ b/tests/test_plugin/test_load.py
@@ -71,6 +71,108 @@ async def test_load_nested_plugin_by_id():
 
 
 @pytest.mark.asyncio
+async def test_load_multinested_plugin():
+    parent_plugin = nonebot.get_plugin(("multinested",))
+    sub_plugin1 = nonebot.get_plugin(("multinested", "multinested_subnested1"))
+    sub_plugin2 = nonebot.get_plugin(("multinested", "multinested_subnested2"))
+    same_plugin1 = nonebot.get_plugin(("multinested", "multinested_samename_subplugin"))
+
+    same_plugin1_sub_same = nonebot.get_plugin(
+        (
+            "multinested",
+            "multinested_samename_subplugin",
+            "multinested_samename_subplugin",
+        )
+    )
+    same_plugin1_sub_another = nonebot.get_plugin(
+        (
+            "multinested",
+            "multinested_samename_subplugin",
+            "multinested_samename_anotherplugin",
+        )
+    )
+    sub_plugin1_sub_same = nonebot.get_plugin(
+        (
+            "multinested",
+            "multinested_subnested1",
+            "multinested_samename_subplugin",
+        )
+    )
+    sub_plugin1_sub_another = nonebot.get_plugin(
+        (
+            "multinested",
+            "multinested_subnested1",
+            "multinested_subnested1_plugin",
+        )
+    )
+    sub_plugin2_sub_same = nonebot.get_plugin(
+        (
+            "multinested",
+            "multinested_subnested2",
+            "multinested_samename_subplugin",
+        )
+    )
+    sub_plugin2_sub_another = nonebot.get_plugin(
+        (
+            "multinested",
+            "multinested_subnested2",
+            "multinested_subnested2_plugin",
+        )
+    )
+    assert parent_plugin
+    assert sub_plugin1
+    assert sub_plugin2
+    assert same_plugin1
+    assert same_plugin1_sub_same
+    assert same_plugin1_sub_another
+    assert sub_plugin1_sub_same
+    assert sub_plugin1_sub_another
+    assert sub_plugin2_sub_same
+    assert sub_plugin2_sub_another
+
+    assert same_plugin1_sub_same.module.a == "subsame.subsame"
+    assert same_plugin1_sub_another.module.a == "subsame.another"
+    assert sub_plugin1_sub_same.module.a == "sub1.subsame"
+    assert sub_plugin1_sub_another.module.a == "sub1.another"
+    assert sub_plugin2_sub_same.module.a == "sub2.subsame"
+    assert sub_plugin2_sub_another.module.a == "sub2.another"
+
+
+@pytest.mark.asyncio
+async def test_load_multinested_plugin_by_name():
+    plugin = nonebot.get_plugin("multinested_samename_subplugin")
+
+    same1 = nonebot.get_plugin(("multinested", "multinested_samename_subplugin"))
+    same2 = nonebot.get_plugin(
+        (
+            "multinested",
+            "multinested_samename_subplugin",
+            "multinested_samename_subplugin",
+        )
+    )
+    same3 = nonebot.get_plugin(
+        (
+            "multinested",
+            "multinested_subnested1",
+            "multinested_samename_subplugin",
+        )
+    )
+    same4 = nonebot.get_plugin(
+        (
+            "multinested",
+            "multinested_subnested2",
+            "multinested_samename_subplugin",
+        )
+    )
+    assert plugin
+    assert same1
+    assert same2
+    assert same3
+    assert same4
+    assert plugin in (same1, same2, same3, same4)
+
+
+@pytest.mark.asyncio
 async def test_load_json():
     nonebot.load_from_json("./plugins.json")
 

--- a/tests/test_plugin/test_load.py
+++ b/tests/test_plugin/test_load.py
@@ -140,6 +140,9 @@ async def test_load_multinested_plugin():
 
 @pytest.mark.asyncio
 async def test_load_multinested_plugin_by_name():
+    """
+    get plugin by name, but only one of the plugins with the same name can be obtained
+    """
     plugin = nonebot.get_plugin("multinested_samename_subplugin")
 
     same1 = nonebot.get_plugin(("multinested", "multinested_samename_subplugin"))
@@ -226,6 +229,10 @@ async def test_require_not_loaded(monkeypatch: pytest.MonkeyPatch):
 
     assert len(_managers) == num_managers
 
+    nonebot.require(("require_not_loaded",))
+
+    assert len(_managers) == num_managers
+
 
 @pytest.mark.asyncio
 async def test_require_not_declared():
@@ -241,6 +248,9 @@ async def test_require_not_declared():
 async def test_require_not_found():
     with pytest.raises(RuntimeError):
         nonebot.require("some_plugin_not_exist")
+
+    with pytest.raises(RuntimeError):
+        nonebot.require(("some_plugin_id_not_exist",))
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin/test_load.py
+++ b/tests/test_plugin/test_load.py
@@ -58,6 +58,19 @@ async def test_load_nested_plugin():
 
 
 @pytest.mark.asyncio
+async def test_load_nested_plugin_by_id():
+    parent_plugin = nonebot.get_plugin(("nested",))
+    sub_plugin = nonebot.get_plugin(("nested", "nested_subplugin"))
+    sub_plugin2 = nonebot.get_plugin(("nested", "nested_subplugin2"))
+    assert parent_plugin
+    assert sub_plugin
+    assert sub_plugin2
+    assert sub_plugin.parent_plugin is parent_plugin
+    assert sub_plugin2.parent_plugin is parent_plugin
+    assert parent_plugin.sub_plugins == {sub_plugin, sub_plugin2}
+
+
+@pytest.mark.asyncio
 async def test_load_json():
     nonebot.load_from_json("./plugins.json")
 

--- a/tests/test_plugin/test_load.py
+++ b/tests/test_plugin/test_load.py
@@ -137,18 +137,21 @@ async def test_load_multinested_plugin():
     assert sub_plugin2_sub_same.module.a == "sub2.subsame"
     assert sub_plugin2_sub_another.module.a == "sub2.another"
 
-    assert same_plugin1.fullpath == ("multinested", "multinested_samename_subplugin")
-    assert same_plugin1_sub_same.fullpath == (
+    assert same_plugin1.plugin_fullpath == (
+        "multinested",
+        "multinested_samename_subplugin",
+    )
+    assert same_plugin1_sub_same.plugin_fullpath == (
         "multinested",
         "multinested_samename_subplugin",
         "multinested_samename_subplugin",
     )
-    assert sub_plugin1_sub_same.fullpath == (
+    assert sub_plugin1_sub_same.plugin_fullpath == (
         "multinested",
         "multinested_subnested1",
         "multinested_samename_subplugin",
     )
-    assert sub_plugin2_sub_same.fullpath == (
+    assert sub_plugin2_sub_same.plugin_fullpath == (
         "multinested",
         "multinested_subnested2",
         "multinested_samename_subplugin",

--- a/tests/test_plugin/test_load.py
+++ b/tests/test_plugin/test_load.py
@@ -137,6 +137,23 @@ async def test_load_multinested_plugin():
     assert sub_plugin2_sub_same.module.a == "sub2.subsame"
     assert sub_plugin2_sub_another.module.a == "sub2.another"
 
+    assert same_plugin1.fullpath == ("multinested", "multinested_samename_subplugin")
+    assert same_plugin1_sub_same.fullpath == (
+        "multinested",
+        "multinested_samename_subplugin",
+        "multinested_samename_subplugin",
+    )
+    assert sub_plugin1_sub_same.fullpath == (
+        "multinested",
+        "multinested_subnested1",
+        "multinested_samename_subplugin",
+    )
+    assert sub_plugin2_sub_same.fullpath == (
+        "multinested",
+        "multinested_subnested2",
+        "multinested_samename_subplugin",
+    )
+
 
 @pytest.mark.asyncio
 async def test_load_multinested_plugin_by_name():


### PR DESCRIPTION
现在可以有两个相同名称的插件了，插件的索引标识改为使用顶层插件到该插件的插件路径。

如果有以下目录：

```
src/
  plugins/
    nested1/
      plugins/
        plugin.py
    nested2/
      plugins/
        plugin.py
```

此时 `nested1` 的路径为 ("nested1",)
`nested1/plugins/plugin.py` 的路径为 ("nested1", "plugin")
`nested2/plugins/plugin.py` 的路径为 ("nested2", "plugin")
因为两个 `plugin` 的路径不同，因此可以两个插件都加载

修改 `_plugin` 字典的 `key`，同时存储插件名和插件路径，它们都映射到这个插件，这应该可以保证向下兼容
现在， `require` 和 `get_plugin` 方法可以通过插件路径获取到插件了

冲突：如果存在同名插件，那么如果通过插件名来获取插件，将获取这些同名插件之中的随机一个，且无法保证获取哪一个，但旧版本插件应该不会出现同名（