### PR TITLE
Bug: inherit_supported_adapters 在展开缩写前取交集

### DIFF
--- a/nonebot/plugin/load.py
+++ b/nonebot/plugin/load.py
@@ -199,9 +199,6 @@ def inherit_supported_adapters(*names: str) -> Optional[set[str]]:
     """
     final_supported: Optional[set[str]] = None
 
-    def adapter_name_expand(name: str) -> str:
-        return f"nonebot.adapters.{name[1:]}" if name.startswith("~") else name
-
     for name in names:
         plugin = get_plugin(_module_name_to_plugin_name(name))
         if plugin is None:
@@ -213,7 +210,7 @@ def inherit_supported_adapters(*names: str) -> Optional[set[str]]:
         if not (raw := meta.supported_adapters):
             continue
 
-        support = {adapter_name_expand(adapter) for adapter in raw}
+        support = {f"nonebot.adapters.{adapter[1:]}" if name.startswith("~") else adapter for adapter in raw}
 
         final_supported = (
             support if final_supported is None else (final_supported & support)

--- a/nonebot/plugin/load.py
+++ b/nonebot/plugin/load.py
@@ -207,11 +207,11 @@ def inherit_supported_adapters(*names: str) -> Optional[set[str]]:
         if meta is None:
             raise ValueError(f'Plugin "{name}" has no metadata!')
 
-        if not (raw := meta.supported_adapters):
+        if (raw := meta.supported_adapters) is None:
             continue
 
         support = {
-            f"nonebot.adapters.{adapter[1:]}" if name.startswith("~") else adapter
+            f"nonebot.adapters.{adapter[1:]}" if adapter.startswith("~") else adapter
             for adapter in raw
         }
 

--- a/nonebot/plugin/load.py
+++ b/nonebot/plugin/load.py
@@ -199,6 +199,9 @@ def inherit_supported_adapters(*names: str) -> Optional[set[str]]:
     """
     final_supported: Optional[set[str]] = None
 
+    def adapter_name_expand(name: str) -> str:
+        return f"nonebot.adapters.{name[1:]}" if name.startswith("~") else name
+
     for name in names:
         plugin = get_plugin(_module_name_to_plugin_name(name))
         if plugin is None:
@@ -206,18 +209,14 @@ def inherit_supported_adapters(*names: str) -> Optional[set[str]]:
         meta = plugin.metadata
         if meta is None:
             raise ValueError(f'Plugin "{name}" has no metadata!')
-        support = meta.supported_adapters
-        if support is None:
+
+        if not (raw := meta.supported_adapters):
             continue
+
+        support = {adapter_name_expand(adapter) for adapter in raw}
+
         final_supported = (
             support if final_supported is None else (final_supported & support)
         )
 
-    return final_supported and {
-        (
-            f"nonebot.adapters.{adapter_name[1:]}"
-            if adapter_name.startswith("~")
-            else adapter_name
-        )
-        for adapter_name in final_supported
-    }
+    return final_supported

--- a/nonebot/plugin/load.py
+++ b/nonebot/plugin/load.py
@@ -210,7 +210,10 @@ def inherit_supported_adapters(*names: str) -> Optional[set[str]]:
         if not (raw := meta.supported_adapters):
             continue
 
-        support = {f"nonebot.adapters.{adapter[1:]}" if name.startswith("~") else adapter for adapter in raw}
+        support = {
+            f"nonebot.adapters.{adapter[1:]}" if name.startswith("~") else adapter
+            for adapter in raw
+        }
 
         final_supported = (
             support if final_supported is None else (final_supported & support)

--- a/tests/plugins/metadata_3.py
+++ b/tests/plugins/metadata_3.py
@@ -1,0 +1,15 @@
+from nonebot.plugin import PluginMetadata
+
+__plugin_meta__ = PluginMetadata(
+    name="测试插件3",
+    description="测试继承适配器, 使用内置适配器全名",
+    usage="无法使用",
+    type="application",
+    homepage="https://nonebot.dev",
+    supported_adapters={
+        "nonebot.adapters.onebot.v11",
+        "nonebot.adapters.onebot.v12",
+        "~qq",
+    },
+    extra={"author": "NoneBot"},
+)

--- a/tests/test_plugin/test_load.py
+++ b/tests/test_plugin/test_load.py
@@ -157,46 +157,73 @@ async def test_inherit_supported_adapters_not_found():
         inherit_supported_adapters("export")
 
 
-inherit_map = {
-    ("echo",): None,
-    ("metadata",): {
-        "nonebot.adapters.onebot.v11",
-        "plugins.metadata:FakeAdapter",
-    },
-    ("metadata_2",): {
-        "nonebot.adapters.onebot.v11",
-        "nonebot.adapters.onebot.v12",
-    },
-    ("metadata_3",): {
-        "nonebot.adapters.onebot.v11",
-        "nonebot.adapters.onebot.v12",
-        "nonebot.adapters.qq",
-    },
-    ("metadata", "metadata_2"): {
-        "nonebot.adapters.onebot.v11",
-    },
-    ("metadata", "metadata_3"): {
-        "nonebot.adapters.onebot.v11",
-    },
-    ("metadata_2", "metadata_3"): {
-        "nonebot.adapters.onebot.v11",
-        "nonebot.adapters.onebot.v12",
-    },
-    ("metadata", "metadata_2", "metadata_3"): {
-        "nonebot.adapters.onebot.v11",
-    },
-    ("metadata", "echo"): {
-        "nonebot.adapters.onebot.v11",
-        "plugins.metadata:FakeAdapter",
-    },
-    ("metadata", "metadata_2", "echo"): {
-        "nonebot.adapters.onebot.v11",
-    },
-}
-
-
 @pytest.mark.asyncio
-@pytest.mark.parametrize(("inherit_plugins", "expected"), inherit_map.items())
+@pytest.mark.parametrize(
+    ("inherit_plugins", "expected"),
+    [
+        (("echo",), None),
+        (
+            ("metadata",),
+            {
+                "nonebot.adapters.onebot.v11",
+                "plugins.metadata:FakeAdapter",
+            },
+        ),
+        (
+            ("metadata_2",),
+            {
+                "nonebot.adapters.onebot.v11",
+                "nonebot.adapters.onebot.v12",
+            },
+        ),
+        (
+            ("metadata_3",),
+            {
+                "nonebot.adapters.onebot.v11",
+                "nonebot.adapters.onebot.v12",
+                "nonebot.adapters.qq",
+            },
+        ),
+        (
+            ("metadata", "metadata_2"),
+            {
+                "nonebot.adapters.onebot.v11",
+            },
+        ),
+        (
+            ("metadata", "metadata_3"),
+            {
+                "nonebot.adapters.onebot.v11",
+            },
+        ),
+        (
+            ("metadata_2", "metadata_3"),
+            {
+                "nonebot.adapters.onebot.v11",
+                "nonebot.adapters.onebot.v12",
+            },
+        ),
+        (
+            ("metadata", "metadata_2", "metadata_3"),
+            {
+                "nonebot.adapters.onebot.v11",
+            },
+        ),
+        (
+            ("metadata", "echo"),
+            {
+                "nonebot.adapters.onebot.v11",
+                "plugins.metadata:FakeAdapter",
+            },
+        ),
+        (
+            ("metadata", "metadata_2", "echo"),
+            {
+                "nonebot.adapters.onebot.v11",
+            },
+        ),
+    ],
+)
 async def test_inherit_supported_adapters_combine(
     inherit_plugins: tuple[str], expected: set[str]
 ):


### PR DESCRIPTION
修复前:
插件A: `{"~qq", "~kook"}`
插件B: `{"nonebot.adapters.qq", "nonebot.adapters.kook"}`
结果为空

修复后
结果为 `{"nonebot.adapters.qq", "nonebot.adapters.kook"}`