### PR TITLE
Plugin: 移除已在 PyPI 上删除的 `covid` 插件和 `molar-mass` 插件

### DIFF
--- a/assets/plugins.json
+++ b/assets/plugins.json
@@ -867,13 +867,6 @@
     "is_official": false
   },
   {
-    "module_name": "nonebot_plugin_covid",
-    "project_link": "nonebot-plugin-covid",
-    "author": "nicklly",
-    "tags": [],
-    "is_official": false
-  },
-  {
     "module_name": "nonebot_plugin_yulu",
     "project_link": "nonebot-plugin-yulu",
     "author": "bingqiu456",
@@ -2540,13 +2533,6 @@
     "module_name": "nonebot_plugin_pvz",
     "project_link": "nonebot-plugin-pvz",
     "author": "longchengguxiao",
-    "tags": [],
-    "is_official": false
-  },
-  {
-    "module_name": "nonebot_plugin_molar_mass",
-    "project_link": "nonebot-plugin-molar-mass",
-    "author": "kifuan",
     "tags": [],
     "is_official": false
   },


### PR DESCRIPTION
目前已经发现插件 `nonebot-plugin-covid` 和 `nonebot-plugin-molar-mass` 已在 PyPI 上删除无法访问，建议将其移出插件索引。