### PR TITLE
Docs: 修复单元测试示例代码

### DIFF
--- a/website/docs/best-practice/testing/README.mdx
+++ b/website/docs/best-practice/testing/README.mdx
@@ -150,7 +150,7 @@ async def test_weather(app: App):
         time=datetime.now(),
         self_id="test",
         message=Message("/天气 北京"),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 ```
 
@@ -165,7 +165,7 @@ async def test_weather(app: App):
         time=datetime.now(),
         self_id="test",
         message=Message("/天气 北京"),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
     async with app.test_matcher(weather) as ctx:
         bot = ctx.create_bot()
@@ -184,7 +184,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio

--- a/website/docs/best-practice/testing/behavior.mdx
+++ b/website/docs/best-practice/testing/behavior.mdx
@@ -56,7 +56,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -95,7 +95,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -131,7 +131,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -202,7 +202,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -264,7 +264,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio

--- a/website/versioned_docs/version-2.2.1/best-practice/testing/README.mdx
+++ b/website/versioned_docs/version-2.2.1/best-practice/testing/README.mdx
@@ -150,7 +150,7 @@ async def test_weather(app: App):
         time=datetime.now(),
         self_id="test",
         message=Message("/天气 北京"),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 ```
 
@@ -165,7 +165,7 @@ async def test_weather(app: App):
         time=datetime.now(),
         self_id="test",
         message=Message("/天气 北京"),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
     async with app.test_matcher(weather) as ctx:
         bot = ctx.create_bot()
@@ -184,7 +184,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio

--- a/website/versioned_docs/version-2.2.1/best-practice/testing/behavior.mdx
+++ b/website/versioned_docs/version-2.2.1/best-practice/testing/behavior.mdx
@@ -56,7 +56,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -95,7 +95,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -131,7 +131,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -202,7 +202,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -264,7 +264,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio

--- a/website/versioned_docs/version-2.3.0/best-practice/testing/README.mdx
+++ b/website/versioned_docs/version-2.3.0/best-practice/testing/README.mdx
@@ -150,7 +150,7 @@ async def test_weather(app: App):
         time=datetime.now(),
         self_id="test",
         message=Message("/天气 北京"),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 ```
 
@@ -165,7 +165,7 @@ async def test_weather(app: App):
         time=datetime.now(),
         self_id="test",
         message=Message("/天气 北京"),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
     async with app.test_matcher(weather) as ctx:
         bot = ctx.create_bot()
@@ -184,7 +184,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio

--- a/website/versioned_docs/version-2.3.0/best-practice/testing/behavior.mdx
+++ b/website/versioned_docs/version-2.3.0/best-practice/testing/behavior.mdx
@@ -56,7 +56,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -95,7 +95,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -131,7 +131,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -202,7 +202,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -264,7 +264,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio

--- a/website/versioned_docs/version-2.3.1/best-practice/testing/README.mdx
+++ b/website/versioned_docs/version-2.3.1/best-practice/testing/README.mdx
@@ -150,7 +150,7 @@ async def test_weather(app: App):
         time=datetime.now(),
         self_id="test",
         message=Message("/天气 北京"),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 ```
 
@@ -165,7 +165,7 @@ async def test_weather(app: App):
         time=datetime.now(),
         self_id="test",
         message=Message("/天气 北京"),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
     async with app.test_matcher(weather) as ctx:
         bot = ctx.create_bot()
@@ -184,7 +184,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio

--- a/website/versioned_docs/version-2.3.1/best-practice/testing/behavior.mdx
+++ b/website/versioned_docs/version-2.3.1/best-practice/testing/behavior.mdx
@@ -56,7 +56,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -95,7 +95,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -131,7 +131,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -202,7 +202,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio
@@ -264,7 +264,7 @@ def make_event(message: str = "") -> MessageEvent:
         time=datetime.now(),
         self_id="test",
         message=Message(message),
-        user=User(user_id=123456789),
+        user=User(id="user"),
     )
 
 @pytest.mark.asyncio


### PR DESCRIPTION
修复使用 `console` 适配器的单元测试示例代码中的 `User` 参数

```python
class User:
    """用户"""

    id: str
    avatar: str = field(default="👤")
    nickname: str = field(default="User")
```

相关 PR：https://github.com/nonebot/adapter-console/pull/34