### PR TITLE
Fix: 声明为 str 的配置项在 dotenv 中写为纯数字时在 Pydantic 2 下的解析错误

### DIFF
--- a/nonebot/config.py
+++ b/nonebot/config.py
@@ -256,8 +256,9 @@ class DotEnvSettingsSource(BaseSettingsSource):
         # remain user custom config
         for env_name in env_file_vars:
             env_val = env_vars[env_name]
-            if env_val and (val_striped := env_val.strip()):
+            if env_val and (val_striped := env_val.strip()).startswith(("[", "{")):
                 # there's a value, decode that as JSON
+                # fuck pydantic2's type_validate_python, just load arrays and objects
                 try:
                     env_val = json.loads(val_striped)
                 except ValueError:


### PR DESCRIPTION
写的有点暴力

<details>

```py
from pydantic import BaseModel, TypeAdapter


class Model(BaseModel):
    a: int
    b: str


print(TypeAdapter(Model).validate_python({"a": "1", "b": "2"}))
print(TypeAdapter(Model).validate_python({"a": 1, "b": 2}))
```

```pytb
a=1 b='2'
Traceback (most recent call last):
  File "d:\Coding\python\nb2-workspace\private\test-nb2\debug.py", line 10, in <module>
    print(TypeAdapter(Model).validate_python({"a": 1, "b": 2}))
  File "D:\Coding\python\nb2-workspace\.venv\lib\site-packages\pydantic\type_adapter.py", line 142, in wrapped
    return func(self, *args, **kwargs)
  File "D:\Coding\python\nb2-workspace\.venv\lib\site-packages\pydantic\type_adapter.py", line 373, in validate_python
    return self.validator.validate_python(object, strict=strict, from_attributes=from_attributes, context=context)
pydantic_core._pydantic_core.ValidationError: 1 validation error for Model
b
  Input should be a valid string [type=string_type, input_value=2, input_type=int]
    For further information visit https://errors.pydantic.dev/2.8/v/string_type
```

</details>

要是 nb 不改就去和 pydantic 爆了吧