### PR TITLE
Plugin: 删除插件 `nonebot-plugin-ntqq-restart`

### DIFF
--- a/assets/plugins.json
+++ b/assets/plugins.json
@@ -6334,26 +6334,6 @@
     "is_official": false
   },
   {
-    "module_name": "nonebot_plugin_ntqq_restart",
-    "project_link": "nonebot-plugin-ntqq-restart",
-    "author": "kanbereina",
-    "tags": [
-      {
-        "label": "llonebot",
-        "color": "#f9e642"
-      },
-      {
-        "label": "NTQQ",
-        "color": "#ede9e9"
-      },
-      {
-        "label": "Windows",
-        "color": "#52aaea"
-      }
-    ],
-    "is_official": false
-  },
-  {
     "module_name": "nonebot_plugin_eve_tool",
     "project_link": "nonebot-plugin-eve-tool",
     "author": "zifox666",


### PR DESCRIPTION
- 🗑️删除插件：`nonebot-plugin-ntqq_restart`

- ℹ️下架原因：

1. 不再维护
2. 因Windows依赖问题无法通过商店插件测试
3. 已转移至新项目[LLOneBot-Master](https://github.com/kanbereina/nonebot-plugin-llob-master)（nonebot-plugin-llob-master）
