### PR TITLE
Plugin: 删除插件 `nonebot-plugin-llob-master`

### DIFF
--- a/assets/plugins.json
+++ b/assets/plugins.json
@@ -6814,22 +6814,6 @@
     "is_official": false
   },
   {
-    "module_name": "nonebot_plugin_llob_master",
-    "project_link": "nonebot-plugin-llob-master",
-    "author": "kanbereina",
-    "tags": [
-      {
-        "label": "LLOneBot",
-        "color": "#e3e9e9"
-      },
-      {
-        "label": "Windows",
-        "color": "#1da6eb"
-      }
-    ],
-    "is_official": false
-  },
-  {
     "module_name": "nonebot_plugin_yoyogame",
     "project_link": "nonebot-plugin-yoyogame",
     "author": "ChenXu233",


### PR DESCRIPTION
🗑️删除插件：[nonebot-plugin-llob-master](https://github.com/kanbereina/nonebot-plugin-llob-master)

ℹ️下架原因：因学业精力有限，不再维护