### PR TITLE
Plugin: 删除插件 nonebot_plugin_clovers

### DIFF
--- a/assets/plugins.json5
+++ b/assets/plugins.json5
@@ -5698,13 +5698,6 @@
     "is_official": false
   },
   {
-    "module_name": "nonebot_plugin_clovers",
-    "project_link": "nonebot-plugin-clovers",
-    "author_id": 51886078,
-    "tags": [],
-    "is_official": false
-  },
-  {
     "module_name": "nonebot_plugin_hx_yinying",
     "project_link": "nonebot-plugin-hx-yinying",
     "author_id": 121207415,


### PR DESCRIPTION
这个插件已经删除了全部on响应器,已经是一个普通模块了，不适合再当做插件用