### PR TITLE
CI: 升级文档构建 node 版本

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,8 +6,8 @@ runs:
   steps:
     - uses: actions/setup-node@v5
       with:
-        node-version: "18"
-        cache: "yarn"
+        node-version: lts/latest
+        cache: yarn
 
     - run: yarn install --frozen-lockfile
       shell: bash

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: actions/setup-node@v5
       with:
-        node-version: lts/latest
+        node-version: lts/*
         cache: yarn
 
     - run: yarn install --frozen-lockfile


### PR DESCRIPTION
This pull request updates the Node.js setup configuration in the GitHub Actions workflow to use the latest LTS version instead of a fixed version. This ensures that the project always runs on the most up-to-date, stable Node.js release.

* GitHub Actions: Changed the `node-version` in `.github/actions/setup-node/action.yml` from `"18"` to `lts/*` to automatically use the latest LTS Node.js version.