### PR TITLE
Feature: 添加 command_regex 规则用于命令与参数正则的组合匹配

### DIFF
--- a/nonebot/rule.py
+++ b/nonebot/rule.py
@@ -677,8 +677,7 @@ class CommandRegexRule:
 
     def __repr__(self) -> str:
         return (
-            f"CommandRegex(cmds={self.cmds}, regex={self.regex!r}, "
-            f"flags={self.flags})"
+            f"CommandRegex(cmds={self.cmds}, regex={self.regex!r}, flags={self.flags})"
         )
 
     def __eq__(self, other: object) -> bool:

--- a/nonebot/rule.py
+++ b/nonebot/rule.py
@@ -654,6 +654,118 @@ def shell_command(
     return Rule(ShellCommandRule(commands, parser))
 
 
+class CommandRegexRule:
+    """检查消息是否为指定命令，且命令参数符合指定的正则表达式。
+
+    参数:
+        cmds: 指定命令元组列表
+        regex: 命令参数的正则表达式
+        flags: 正则表达式标记
+    """
+
+    __slots__ = ("cmds", "flags", "regex")
+
+    def __init__(
+        self,
+        cmds: list[tuple[str, ...]],
+        regex: str,
+        flags: int = 0,
+    ):
+        self.cmds = tuple(cmds)
+        self.regex = regex
+        self.flags = flags
+
+    def __repr__(self) -> str:
+        return (
+            f"CommandRegex(cmds={self.cmds}, regex={self.regex!r}, "
+            f"flags={self.flags})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, CommandRegexRule)
+            and frozenset(self.cmds) == frozenset(other.cmds)
+            and self.regex == other.regex
+            and self.flags == other.flags
+        )
+
+    def __hash__(self) -> int:
+        return hash((frozenset(self.cmds), self.regex, self.flags))
+
+    async def __call__(
+        self,
+        state: T_State,
+        cmd: tuple[str, ...] | None = Command(),
+        cmd_arg: Message | None = CommandArg(),
+    ) -> bool:
+        if cmd not in self.cmds:
+            return False
+        arg_text = "" if cmd_arg is None else str(cmd_arg)
+        if matched := re.search(self.regex, arg_text, self.flags):
+            state[REGEX_MATCHED] = matched
+            return True
+        return False
+
+
+def command_regex(
+    *cmds: str | tuple[str, ...],
+    regex: str,
+    flags: int | re.RegexFlag = 0,
+) -> Rule:
+    """匹配消息命令，并对命令参数进行正则匹配。
+
+    根据配置里提供的 {ref}``command_start` <nonebot.config.Config.command_start>`,
+    {ref}``command_sep` <nonebot.config.Config.command_sep>` 判断消息是否为命令，
+    随后对命令参数（{ref}`nonebot.params.CommandArg`）使用 `re.search`
+    检查是否匹配指定正则表达式。
+
+    可以通过 {ref}`nonebot.params.Command` 获取匹配成功的命令（例: `("remind",)`），
+    通过 {ref}`nonebot.params.RawCommand` 获取匹配成功的原始命令文本（例: `"/remind"`），
+    通过 {ref}`nonebot.params.CommandArg` 获取匹配成功的命令参数，
+    通过 {ref}`nonebot.params.RegexStr` 获取匹配成功的字符串，
+    通过 {ref}`nonebot.params.RegexGroup` 获取匹配成功的 group 元组,
+    通过 {ref}`nonebot.params.RegexDict` 获取匹配成功的 group 字典。
+
+    参数:
+        cmds: 命令文本或命令元组
+        regex: 命令参数的正则表达式
+        flags: 正则表达式标记
+
+    用法:
+        使用默认 `command_start`, `command_sep` 配置情况下：
+
+        命令 `("remind",)` 配合正则 `r"^(.+) in (\\d+)m$"` 可以匹配:
+        `/remind buy milk in 30m`，并通过 group 获取 `("buy milk", "30")`。
+
+    :::tip 提示
+    正则表达式匹配使用 `search` 而非 `match`，如需从头匹配请使用 `r"^xxx"` 来确保匹配开头。
+    匹配的对象是 `CommandArg` 的字符串形式（不含命令本身），同 {ref}`nonebot.rule.regex`
+    一样使用 `Message` 的 `str` 字符串。
+    :::
+    """
+
+    config = get_driver().config
+    command_start = config.command_start
+    command_sep = config.command_sep
+    commands: list[tuple[str, ...]] = []
+    for command in cmds:
+        if isinstance(command, str):
+            command = (command,)
+
+        commands.append(command)
+
+        if len(command) == 1:
+            for start in command_start:
+                TrieRule.add_prefix(f"{start}{command[0]}", TRIE_VALUE(start, command))
+        else:
+            for start, sep in product(command_start, command_sep):
+                TrieRule.add_prefix(
+                    f"{start}{sep.join(command)}", TRIE_VALUE(start, command)
+                )
+
+    return Rule(CommandRegexRule(commands, regex, flags))
+
+
 class RegexRule:
     """检查消息字符串是否符合指定正则表达式。
 

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -22,6 +22,7 @@ from nonebot.rule import (
     CMD_RESULT,
     TRIE_VALUE,
     ArgumentParser,
+    CommandRegexRule,
     CommandRule,
     EndswithRule,
     FullmatchRule,
@@ -35,6 +36,7 @@ from nonebot.rule import (
     ToMeRule,
     TrieRule,
     command,
+    command_regex,
     endswith,
     fullmatch,
     is_type,
@@ -341,6 +343,91 @@ async def test_command(
         PREFIX_KEY: {CMD_KEY: cmd, CMD_WHITESPACE_KEY: whitespace, CMD_ARG_KEY: arg}
     }
     assert await dependent(state=state) == expected
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("cmds", "pattern", "flags", "cmd", "arg_text", "expected", "matched_groups"),
+    [
+        # command + regex match
+        ((("remind",),), r"^(.+) in (\d+)m$", 0, ("remind",), "buy milk in 30m",
+         True, ("buy milk", "30")),
+        # command match but regex does not match
+        ((("remind",),), r"^(.+) in (\d+)m$", 0, ("remind",), "buy milk", False, None),
+        # regex matches but command does not match
+        ((("remind",),), r"^(.+) in (\d+)m$", 0, ("foo",), "buy milk in 30m",
+         False, None),
+        # command does not match (None)
+        ((("remind",),), r".*", 0, None, "anything", False, None),
+        # multiple commands - second matches
+        ((("ping",), ("pong",)), r"^\d+$", 0, ("pong",), "123", True, ("123",)),
+        # multiple commands - none matches
+        ((("ping",), ("pong",)), r"^\d+$", 0, ("ping",), "abc", False, None),
+        # search semantics: pattern matches anywhere in arg
+        ((("test",),), r"\d+", 0, ("test",), "hello42world", True, ("42",)),
+        # nested command tuple
+        ((("a", "b"),), r"^foo$", 0, ("a", "b"), "foo", True, ()),
+        # empty arg with pattern requiring chars
+        ((("test",),), r".+", 0, ("test",), None, False, None),
+        # case-insensitive flag
+        ((("greet",),), r"^hello$", re.IGNORECASE, ("greet",), "HELLO", True, ()),
+    ],
+)
+async def test_command_regex(
+    cmds: tuple[tuple[str, ...]],
+    pattern: str,
+    flags: int,
+    cmd: tuple[str, ...] | None,
+    arg_text: str | None,
+    expected: bool,
+    matched_groups: tuple[str, ...] | None,
+):
+    test_cmd_regex = command_regex(*cmds, regex=pattern, flags=flags)
+    dependent = next(iter(test_cmd_regex.checkers))
+    checker = dependent.call
+
+    assert isinstance(checker, CommandRegexRule)
+    assert checker.cmds == cmds
+    assert checker.regex == pattern
+    assert checker.flags == flags
+
+    arg = arg_text if arg_text is None else FakeMessage(arg_text)
+    state: T_State = {PREFIX_KEY: {CMD_KEY: cmd, CMD_ARG_KEY: arg}}
+    result = await dependent(state=state)
+    assert result == expected
+
+    if expected:
+        assert REGEX_MATCHED in state
+        assert state[REGEX_MATCHED].groups() == matched_groups
+    else:
+        assert REGEX_MATCHED not in state
+
+
+@pytest.mark.anyio
+async def test_command_regex_eq_hash():
+    rule_a = command_regex("foo", regex=r"\d+")
+    rule_b = command_regex("foo", regex=r"\d+")
+    rule_c = command_regex("foo", regex=r"[a-z]+")
+    rule_d = command_regex("bar", regex=r"\d+")
+    rule_e = command_regex("foo", regex=r"\d+", flags=re.IGNORECASE)
+
+    checker_a = next(iter(rule_a.checkers)).call
+    checker_b = next(iter(rule_b.checkers)).call
+    checker_c = next(iter(rule_c.checkers)).call
+    checker_d = next(iter(rule_d.checkers)).call
+    checker_e = next(iter(rule_e.checkers)).call
+
+    assert checker_a == checker_b
+    assert hash(checker_a) == hash(checker_b)
+    assert checker_a != checker_c
+    assert checker_a != checker_d
+    assert checker_a != checker_e
+    assert checker_a != "not-a-rule"
+
+    repr_str = repr(checker_a)
+    assert "CommandRegex" in repr_str
+    assert "foo" in repr_str
+    assert r"\d+" in repr_str
 
 
 @pytest.mark.anyio

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -350,13 +350,27 @@ async def test_command(
     ("cmds", "pattern", "flags", "cmd", "arg_text", "expected", "matched_groups"),
     [
         # command + regex match
-        ((("remind",),), r"^(.+) in (\d+)m$", 0, ("remind",), "buy milk in 30m",
-         True, ("buy milk", "30")),
+        (
+            (("remind",),),
+            r"^(.+) in (\d+)m$",
+            0,
+            ("remind",),
+            "buy milk in 30m",
+            True,
+            ("buy milk", "30"),
+        ),
         # command match but regex does not match
         ((("remind",),), r"^(.+) in (\d+)m$", 0, ("remind",), "buy milk", False, None),
         # regex matches but command does not match
-        ((("remind",),), r"^(.+) in (\d+)m$", 0, ("foo",), "buy milk in 30m",
-         False, None),
+        (
+            (("remind",),),
+            r"^(.+) in (\d+)m$",
+            0,
+            ("foo",),
+            "buy milk in 30m",
+            False,
+            None,
+        ),
         # command does not match (None)
         ((("remind",),), r".*", 0, None, "anything", False, None),
         # multiple commands - second matches


### PR DESCRIPTION
## 动机

目前若希望对命令的参数做格式校验（例如 `/remind buy milk in 30m`），开发者需要：

1. 先用 `command()` 匹配命令名
2. 再在 handler 内手动取出 `CommandArg()` 并自行 `re.search`
3. 校验失败时还需要手动 `matcher.skip()` 或返回错误提示

这部分逻辑在不同 handler 之间重复，且无法享受 NoneBot 现有的依赖注入收益。单独使用 `regex()` 也不合适——它直接匹配整条消息，无法区分命令前缀，且不会自动处理 `command_start` / `command_sep` 配置。

## 解决方案

新增 `command_regex` 规则，把命令匹配和参数正则匹配组合到同一条规则内：

- 先按 `command_start` / `command_sep` 配置匹配命令（与 `command()` 完全一致，共享同一个 `TrieRule` 前缀注册逻辑）
- 命中命令后，对 `CommandArg` 的字符串形式 `re.search(pattern, ...)`
- 匹配结果存入 `state[REGEX_MATCHED]`，可通过 `RegexMatched()` / `RegexGroup()` / `RegexDict()` 注入到 handler

## 使用示例

```python
from nonebot import on_message
from nonebot.params import RegexGroup
from nonebot.rule import command_regex

remind = on_message(rule=command_regex(
    "remind",
    regex=r"^(.+) in (\d+)m$",
))

@remind.handle()
async def _(groups: tuple[str, ...] = RegexGroup()):
    task, minutes = groups
    await remind.finish(f"我会在 {minutes} 分钟后提醒你「{task}」")
```

可匹配 `/remind buy milk in 30m`，并直接拿到 `("buy milk", "30")`。

## 改动一览

- `nonebot/rule.py`
  - 新增 `CommandRegexRule` 类：`__slots__`、`__init__`、`__repr__`、`__eq__`、`__hash__`、async `__call__`（通过 `Command()` 与 `CommandArg()` 注入）
  - 新增 `command_regex(*cmds, regex, flags=0)` 工厂函数，复用 `command()` 的前缀注册逻辑

- `tests/test_rule.py`
  - 新增 `test_command_regex` 参数化测试，覆盖：命令匹配 + 正则匹配、命令匹配但正则不匹配、命令不匹配、`cmd=None`、多命令分发、`re.search` 语义、嵌套命令元组 `("a", "b")`、空参数、`re.IGNORECASE` 等 10 种场景
  - 新增 `test_command_regex_eq_hash` 验证 `__eq__` / `__hash__` / `__repr__` 行为

合计 +199 / -0 行。

## 兼容性

- 纯新增规则，不修改任何现有 API 和行为
- 复用 `REGEX_MATCHED` state key 与现有 `regex()` 规则一致，保证 `RegexGroup` / `RegexDict` 等参数透明可用
- 复用 `TrieRule` 注册流程，与 `command()` 共享同一个命令解析路径

## 检查清单

- [x] 已阅读 [贡献指南](https://github.com/nonebot/nonebot2/blob/master/CONTRIBUTING.md)
- [x] 已添加测试用例
- [x] 已自我 review 代码
- [x] 遵循项目代码风格（与 `CommandRule` / `RegexRule` 一致）
- [x] 不破坏现有公共 API