### PR TITLE
Docs: 添加 WxClaw 适配器

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ NoneBot2 是一个现代、跨平台、可扩展的 Python 聊天机器人框架
   |                             Mail（[仓库](https://github.com/mobyw/nonebot-adapter-mail)）                             |  ↗️  |                         邮件收发协议，由社区贡献                          |
   |     黑盒语音（[仓库](https://github.com/lclbm/adapter-heybox)，[协议](https://github.com/QingFengOpen/HeychatDoc)）     |  ↗️  |                       黑盒语音机器人协议，由社区贡献                             |
   | 微信公众平台（[仓库](https://github.com/YangRucheng/nonebot-adapter-wxmp)，[协议](https://developers.weixin.qq.com/doc/)）|  ↗️  |                       微信公众平台协议，由社区贡献                             |
+  | WxClaw（[仓库](https://github.com/shoucandanghehe/nonebot-adapter-wxclaw)，[协议](https://www.npmjs.com/package/@tencent-weixin/openclaw-weixin)） |  ↗️  |                  微信智能体协议，由社区贡献                   |
   | Gewechat（[仓库](https://github.com/Shine-Light/nonebot-adapter-gewechat)，[协议](https://github.com/Devo919/Gewechat)）|  ❌  |                      Gewechat 微信协议，Gewechat不再维护及可用                            |
   |  EFChat（[仓库](https://github.com/molanp/nonebot_adapter_efchat)，[协议](https://irinu-live.melon.fish/efc-help/)）   |  ↗️  |                            恒五聊平台协议，由社区贡献                          |
   |  VoceChat （[仓库](https://github.com/5656565566/nonebot-adapter-vocechat)，[协议](https://doc.voce.chat/zh-cn/bot/bot-and-webhook)）   |  ↗️  |                            VoceChat 平台协议，由社区贡献                          |


### PR DESCRIPTION
## Summary

- add WxClaw to the README adapter list
- link to the adapter repository and the `@tencent-weixin/openclaw-weixin` protocol package

## Checks

- Verified the README adapter table still has 3 cells per row and includes the WxClaw row with a local script.